### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bin/canada.py
+++ b/bin/canada.py
@@ -40,9 +40,8 @@ def sort_out_tags(source_ckan_uri,
             tag_status.record('Unchanged', mangled_tag, do_print=False)
             continue
         if mangled_tag in tag_replace_map and tag_replace_map[mangled_tag] != replacement_tag:
-            print 'Warning - can\'t differentiate %s : %s / %s' % \
-                  (mangled_tag, tag_replace_map[mangled_tag], replacement_tag)
-        tag_status.record('Mapping added', '%s:%s' % (mangled_tag, replacement_tag), do_print=False)
+            print 'Warning - can\'t differentiate {0!s} : {1!s} / {2!s}'.format(mangled_tag, tag_replace_map[mangled_tag], replacement_tag)
+        tag_status.record('Mapping added', '{0!s}:{1!s}'.format(mangled_tag, replacement_tag), do_print=False)
         tag_replace_map[mangled_tag] = replacement_tag
     example_map = tag_replace_map.items()[0]
     print tag_status
@@ -53,7 +52,7 @@ def sort_out_tags(source_ckan_uri,
     # edit packages
     pkg_status = Status('Packages')
     pkgs = ckan2.group_entity_get(group)['packages']
-    print 'Packages in the group: %i' % len(pkgs)
+    print 'Packages in the group: {0:d}'.format(len(pkgs))
     for pkg_name in pkgs:
         pkg = ckan2.package_entity_get(pkg_name)
         original_pkg = copy.deepcopy(pkg)
@@ -69,7 +68,7 @@ def sort_out_tags(source_ckan_uri,
 
         if set(pkg['tags']) != set(edited_tags):
             pkg['tags'] = edited_tags
-            print '%s: %r -> %r' % (pkg_name, sorted(original_pkg['tags']), sorted(edited_tags))
+            print '{0!s}: {1!r} -> {2!r}'.format(pkg_name, sorted(original_pkg['tags']), sorted(edited_tags))
 
         if pkg == original_pkg:
             pkg_status.record('Unchanged', pkg_name)
@@ -78,7 +77,7 @@ def sort_out_tags(source_ckan_uri,
         try:
             ckan2.package_entity_put(pkg)
         except ckanclient.CkanApiError, e:
-            pkg_status.record('Error: %r' % e.args, pkg_name)
+            pkg_status.record('Error: {0!r}'.format(e.args), pkg_name)
             continue
         
         pkg_status.record('Successfully changed', pkg_name)
@@ -93,7 +92,7 @@ parser.add_option("-k", "--destination-ckan-api-key", dest="destination_ckan_api
 
 (options, args) = parser.parse_args()
 
-assert len(args) == 2, 'The source and destination CKAN API URIs are the only two arguments. Found: %r' % args
+assert len(args) == 2, 'The source and destination CKAN API URIs are the only two arguments. Found: {0!r}'.format(args)
 source_ckan_uri, destination_ckan_uri = args
 print 'Key: ', options.destination_ckan_api_key
 

--- a/bin/ckan-edit-tags2.py
+++ b/bin/ckan-edit-tags2.py
@@ -10,7 +10,7 @@ for pkg in model.Session.query(model.Package):
     source = pkg.extras.get('import_source', u'')
     ns = pkg.extras.get('national_statistic', u'')
     remove_national_statistic = not source.startswith('ONS-') and ns == 'yes'
-    print 'Package: name=%s national_statistic=%s source=%s remove_ns=%s' % (pkg.name, ns, source, remove_national_statistic)
+    print 'Package: name={0!s} national_statistic={1!s} source={2!s} remove_ns={3!s}'.format(pkg.name, ns, source, remove_national_statistic)
     
     if remove_national_statistic:
         pkg.extras['national_statistic'] = u''

--- a/bin/ckan-hmg-breakdown.py
+++ b/bin/ckan-hmg-breakdown.py
@@ -9,14 +9,14 @@ from ckan.lib.dumper import SimpleDumper
 
 
 q_packages = model.Session.query(model.Package)
-print 'Total packages: %i' % q_packages.count()
+print 'Total packages: {0:d}'.format(q_packages.count())
 
 active = model.State.ACTIVE
 q_active = q_packages.filter_by(state=active)
-print 'Active packages: %i' % q_active.count()
+print 'Active packages: {0:d}'.format(q_active.count())
 
 q_group = q_packages.join('groups').filter(model.Group.name==u'ukgov')
-print 'Packages in group ukgov: %i' % q_group.count()
+print 'Packages in group ukgov: {0:d}'.format(q_group.count())
 
 print_those_not_in_group = True
 if print_those_not_in_group:
@@ -51,10 +51,10 @@ for pkg in q_packages:
             not_in_group.append(pkg.name)
 if print_those_not_in_group:
     if not_in_group:
-        print ' Not in the group: %s' % ', '.join(not_in_group)
+        print ' Not in the group: {0!s}'.format(', '.join(not_in_group))
     
 for source, pkgs in pkgs_by_source.items():
-    print 'Source: %s \t items: %i' % (source, len(pkgs))
+    print 'Source: {0!s} \t items: {1:d}'.format(source, len(pkgs))
 
 ##ons_pkgs_titles = []
 ##for pkg in pkgs_by_source['ONS']:

--- a/bin/ckan-hmg-update-licenses.py
+++ b/bin/ckan-hmg-update-licenses.py
@@ -43,7 +43,7 @@ for i, pkg_name in enumerate(pkg_names):
         pkg.license = model.Session.query(model.License).get(compliant_crown)
         made_change('Click Use -> Crown Copyright OKD compliant', pkg.name)
     else:
-        made_change('No change - left as license %s' % pkg.license, pkg.name)
+        made_change('No change - left as license {0!s}'.format(pkg.license), pkg.name)
     model.Session.flush()
 
     if i+1 % 100 == 0:
@@ -53,4 +53,4 @@ for i, pkg_name in enumerate(pkg_names):
 model.repo.commit_and_remove()
 
 for description, packages in changes.items():
-    print 'CHANGE: %s (%i)' % (description, len(packages))
+    print 'CHANGE: {0!s} ({1:d})'.format(description, len(packages))

--- a/bin/ckan-rest-edit-tags.py
+++ b/bin/ckan-rest-edit-tags.py
@@ -26,7 +26,7 @@ class TagEditor:
     def edit_tags(self, pkg_name, add_tags, remove_tags):
         pkg = self.ckan.package_entity_get(pkg_name)
         if self.ckan.last_status != 200:
-            print 'Error! Package: %s Error reading package: %s' % (pkg_name, self.ckan.last_status)
+            print 'Error! Package: {0!s} Error reading package: {1!s}'.format(pkg_name, self.ckan.last_status)
             return self.ckan.last_status
         tags = set()
         for tag in pkg['tags']:
@@ -37,13 +37,13 @@ class TagEditor:
         for tag in remove_tags:
             tags.discard(tag)
         if tags == tags_before:
-            print "PKG %s: no change" % (pkg_name)
+            print "PKG {0!s}: no change".format((pkg_name))
             return
-        print "PKG %s: %i->%i tags" % (pkg_name, len(tags_before), len(tags))
+        print "PKG {0!s}: {1:d}->{2:d} tags".format(pkg_name, len(tags_before), len(tags))
         self.ckan.package_entity_put({'name':pkg_name,
                                       'tags':list(tags)})
         if self.ckan.last_status != 200:
-            print 'Error! Package: %s Error writing package: %s' % (pkg_name, self.ckan.last_status)
+            print 'Error! Package: {0!s} Error writing package: {1!s}'.format(pkg_name, self.ckan.last_status)
             return self.ckan.last_status
         return self.ckan.last_status 
         

--- a/bin/ckan_edit_local.py
+++ b/bin/ckan_edit_local.py
@@ -29,7 +29,7 @@ def ons_prefix():
             pkgs_changed.append(pkg.name)
     
     model.Session.remove()
-    print 'Removed ONS prefix from %i packages out of %i' % (len(pkgs_changed), model.Session.query(model.Package).count())
+    print 'Removed ONS prefix from {0:d} packages out of {1:d}'.format(len(pkgs_changed), model.Session.query(model.Package).count())
             
 def dump_data4nr_names(csv_filepath):
     '''Dumps a list of the old and new names for packages in data4nr csv data'''
@@ -46,7 +46,7 @@ def dump_data4nr_names(csv_filepath):
         data4nr_dict = data4nr._parse_line(row_list, index)
         if data4nr_dict:
             old_name, new_name = data4nr._create_name(data4nr_dict)
-            print '%s %s' % (old_name, new_name)
+            print '{0!s} {1!s}'.format(old_name, new_name)
         index += 1
 
 def munge_old_data4nr_names(old_names_filepath):
@@ -69,9 +69,9 @@ def munge_old_data4nr_names(old_names_filepath):
                 break
             bit_of_name = bit_of_name[:-1]
         if new_name:
-            print '%s %s' % (old_name, new_name)
+            print '{0!s} {1!s}'.format(old_name, new_name)
         else:
-            print '%s UNKNOWN' % old_name
+            print '{0!s} UNKNOWN'.format(old_name)
     f_obj.close()
             
 def canada_extras():
@@ -115,7 +115,7 @@ def canada_extras():
                key not in key_mapping.values():
                 unmapped_keys.add(key, pkg.name)
     rev.finished()
-    print 'Packages: %i' % model.Session.query(model.Package).count()
+    print 'Packages: {0:d}'.format(model.Session.query(model.Package).count())
     print 'Changed keys:\n', keys_changed.report()
     print 'Unmapped keys:\n', unmapped_keys.report()
     print 'Changed licenses:\n', licenses_changed.report()
@@ -154,5 +154,5 @@ if __name__ == '__main__':
     elif command == 'canada_extras':
         canada_extras()
     else:
-        print 'Command %r not found' % command
+        print 'Command {0!r} not found'.format(command)
         print usage

--- a/bin/ckan_spam.py
+++ b/bin/ckan_spam.py
@@ -28,7 +28,7 @@ def purge(revision):
     cmd = ckan.commands.revision.PurgeRevision(
             revision=revision,
             leave_record=False)
-    print 'Purging revision: %s' % revision.id
+    print 'Purging revision: {0!s}'.format(revision.id)
     cmd.execute()
 
 def purge_packages_by_name():

--- a/bin/copy-ckan-2-ckan.py
+++ b/bin/copy-ckan-2-ckan.py
@@ -37,7 +37,7 @@ def copy_packages(source_ckan_uri,
                      'title': group_title}
             ckan2.group_register_post(group)
             existing_groups.add(group_name)
-            print 'Created group: %s' % group_name
+            print 'Created group: {0!s}'.format(group_name)
 
     if dest_group_name:
         add_group_if_needed(dest_group_name, dest_group_title)
@@ -45,29 +45,29 @@ def copy_packages(source_ckan_uri,
     existing_pkgs = ckan2.package_register_get()
 
     if site_name:
-        import_tag = 'meta.imported-from.%s' % re.sub('[^a-zA-Z0-9-_.]', '', site_name)
-        print 'Tagging with: %s' % import_tag
+        import_tag = 'meta.imported-from.{0!s}'.format(re.sub('[^a-zA-Z0-9-_.]', '', site_name))
+        print 'Tagging with: {0!s}'.format(import_tag)
     else:
         import_tag = None
     
     # go through all packages
     package_list = ckan1.package_register_get()
-    print 'Found %i packages to copy' % len(package_list)
+    print 'Found {0:d} packages to copy'.format(len(package_list))
 
     if filter:
         filter_re = re.compile(filter)
         package_list = [pkg for pkg in package_list \
                         if filter_re.match(pkg)]
-        print 'Filtered down to %i packages' % len(package_list)
+        print 'Filtered down to {0:d} packages'.format(len(package_list))
     
     for package_ref in package_list[:]:
         try:
             pkg = ckan1.package_entity_get(package_ref)
         except ckanclient.CkanApiNotAuthorizedError:
-            print '!! Not authorized: %s' % package_ref
+            print '!! Not authorized: {0!s}'.format(package_ref)
             package_list.remove(package_ref)
             continue
-        print 'Got package: %s' % pkg['name']
+        print 'Got package: {0!s}'.format(pkg['name'])
 
         # put in groups
         for group_name in pkg['groups']:
@@ -99,13 +99,13 @@ def copy_packages(source_ckan_uri,
             group = ckan2.group_entity_get(group_ref)
             group['packages'].append(pkg['name'])
             ckan2.group_entity_put(group)
-            print '...and added to group %s' % group_ref
+            print '...and added to group {0!s}'.format(group_ref)
 
     if dest_group_name:
         group = ckan2.group_entity_get(dest_group_name)
         pkgs_to_add_to_group = list(set(package_list) - set(group['packages']))
         if pkgs_to_add_to_group:
-            print 'Adding %i packages to group %s: %r' % (len(pkgs_to_add_to_group), dest_group_name, pkgs_to_add_to_group)
+            print 'Adding {0:d} packages to group {1!s}: {2!r}'.format(len(pkgs_to_add_to_group), dest_group_name, pkgs_to_add_to_group)
             group['packages'].extend(pkgs_to_add_to_group)
             ckan2.group_entity_put(group)
 
@@ -141,7 +141,7 @@ parser.add_option("-f", "--filter", dest="filter",
 
 (options, args) = parser.parse_args()
 
-assert len(args) == 2, 'The source and destination CKAN API URIs are the only two arguments. Found: %r' % args
+assert len(args) == 2, 'The source and destination CKAN API URIs are the only two arguments. Found: {0!r}'.format(args)
 source_ckan_uri, destination_ckan_uri = args
 print 'Key: ', options.destination_ckan_api_key
 

--- a/bin/dump_23_pkgs.py
+++ b/bin/dump_23_pkgs.py
@@ -19,9 +19,9 @@ for pkg in model.Session.query(model.Package):
         xl_dict = pkg_to_xl_dict(pkg)
         xl_dicts.append(xl_dict)
 
-print 'Found %i matching packages' % count
+print 'Found {0:d} matching packages'.format(count)
 
 dumper_ = dumper.PackagesXlWriter(xl_dicts)
 dumper_.add_col_titles(('notes', 'url', 'resource-0-url', 'resource-0-format', 'resource-0-description', 'author', 'author_email', 'state', 'version', 'tags', 'groups', 'license' ))
 dumper_.save(open(xl_filename, 'wb'))
-print 'Saved in %s' % xl_filename
+print 'Saved in {0!s}'.format(xl_filename)

--- a/bin/fixes.py
+++ b/bin/fixes.py
@@ -21,7 +21,7 @@ def fix_package_tags():
         mostrecent = revs[0]
         pkgtag.revision_id = mostrecent.revision_id
         count += 1
-    print('Updated %s PackageTags' % count)
+    print('Updated {0!s} PackageTags'.format(count))
     model.Session.commit()
     
     count = 0
@@ -30,13 +30,13 @@ def fix_package_tags():
         pkgtagrev.package_id = pkgtagrev.continuity.package_id
         pkgtagrev.tag_id = pkgtagrev.continuity.tag_id
         count += 1
-    print('Updated %s PackageTagRevisions' % count)
+    print('Updated {0!s} PackageTagRevisions'.format(count))
     model.Session.commit()
 
     count = 0
     for pkgtag in model.Session.query(model.PackageTag).filter_by(package_id=None):
         pkgtag.purge()
         count += 1
-    print('Deleted %s PackageTags' % count)
+    print('Deleted {0!s} PackageTags'.format(count))
     model.Session.commit()
 

--- a/bin/ons-load.py
+++ b/bin/ons-load.py
@@ -5,14 +5,14 @@ data_path = os.path.expanduser('~/ckan-local/data/')
 def load_month(month, year):
     assert month < 13
     assert year > 2000
-    data_filepath = os.path.join(data_path, 'ons_hub_%s_%#02d.xml' % (year, month))
+    data_filepath = os.path.join(data_path, 'ons_hub_{0!s}_{1:02d}.xml'.format(year, month))
     try:
-        cmd = 'paster db load-onshub %s' % (data_filepath)
+        cmd = 'paster db load-onshub {0!s}'.format((data_filepath))
         print cmd
         response = os.system(cmd)
-        print '\n%s %r' % (data_filepath, response)
+        print '\n{0!s} {1!r}'.format(data_filepath, response)
     except Exception, e:
-        print '\nEXCEPTION %s %r' % (data_filepath, e.args)
+        print '\nEXCEPTION {0!s} {1!r}'.format(data_filepath, e.args)
 
 
 load_month(1, 2010)

--- a/bin/running_stats.py
+++ b/bin/running_stats.py
@@ -60,7 +60,7 @@ class StatsCount(dict):
         indent_str = '\t' * indent
         for category in categories:
             value = self.report_value(category)
-            lines.append(indent_str + '%s: %s' % (category, value))
+            lines.append(indent_str + '{0!s}: {1!s}'.format(category, value))
         if not categories:
             lines = [indent_str + 'None']
         return '\n'.join(lines)
@@ -75,7 +75,7 @@ class StatsList(StatsCount):
 
     def report_value(self, category):
         value = self[category]
-        value_str = '%i %r' % (len(value), value)
+        value_str = '{0:d} {1!r}'.format(len(value), value)
         if len(value_str) > self.report_value_limit:
             value_str = value_str[:self.report_value_limit] + '...'
         return value_str

--- a/bin/status.py
+++ b/bin/status.py
@@ -11,16 +11,16 @@ class Status:
     def record(self, status_category, pkg_name, do_print=True):
         self.pkg_status[status_category].append(pkg_name)
         if do_print:
-            print '%s: %s' % (pkg_name, status_category)
+            print '{0!s}: {1!s}'.format(pkg_name, status_category)
         
     def __str__(self):
         status = '\nStatus'
         if self.obj_type_str:
-            status += ' of: %s' % self.obj_type_str
+            status += ' of: {0!s}'.format(self.obj_type_str)
         status += '\n'
         status += '\n'.join([ \
-            '%s: %i (e.g. %s)' % (category, len(pkg_names), sorted(pkg_names)[0]) \
+            '{0!s}: {1:d} (e.g. {2!s})'.format(category, len(pkg_names), sorted(pkg_names)[0]) \
             for (category, pkg_names) in self.pkg_status.items()])
-        status += '\nTotal: %i\n' % sum([len(pkg_names) for pkg_names in self.pkg_status.values()])
+        status += '\nTotal: {0:d}\n'.format(sum([len(pkg_names) for pkg_names in self.pkg_status.values()]))
         return status
         

--- a/bin/talisckan.py
+++ b/bin/talisckan.py
@@ -26,15 +26,15 @@ class TalisCkan:
         return packages
 
     def load_to_talis(self, pkg_name):
-        print '=== Loading %s ===' % pkg_name
+        print '=== Loading {0!s} ==='.format(pkg_name)
         res = self.ckan.package_entity_get(pkg_name)
         if self.ckan.last_status != 200:
-            print 'Failed to read CKAN package %s: %s' % (pkg_name, self.ckan.last_status)
+            print 'Failed to read CKAN package {0!s}: {1!s}'.format(pkg_name, self.ckan.last_status)
             return
         pkg_dict = res
         res = self._talis.post_pkg(pkg_dict)
         if res:
-            print 'Failed to post package %s to Talis: %s' % (pkg_name, res)
+            print 'Failed to post package {0!s} to Talis: {1!s}'.format(pkg_name, res)
             return
 ##        res = self._talis.get_pkg(pkg_name)
 ##        assert res, res

--- a/bin/webstore_test.py
+++ b/bin/webstore_test.py
@@ -19,11 +19,11 @@ class TestWebstoreExternal:
         dataset = json.loads(out.body)
         resource_id = dataset['resources'][0]['id']
 
-        offset = '/api/data/%s' % resource_id
+        offset = '/api/data/{0!s}'.format(resource_id)
         res = testapp.get(offset, status=400)
         assert res.status == 400
 
-        offset = '/api/data/%s/_search?q=a' % resource_id
+        offset = '/api/data/{0!s}/_search?q=a'.format(resource_id)
         res = testapp.get(offset)
         assert res.status == 200
         out = json.loads(res.body)
@@ -35,13 +35,13 @@ class TestWebstoreExternal:
             "message": "Trying out elasticsearch, so far so good?"
             }
         data = json.dumps(data)
-        offset = '/api/data/%s' % resource_id
+        offset = '/api/data/{0!s}'.format(resource_id)
         testapp.put(offset + '/1', data)
         out = testapp.get(offset + '/1')
         outdata = json.loads(out.body)
         assert outdata['_source']['user'] == 'hamlet', outdata
 
-        offset = '/api/data/%s/_search?q=hamlet' % resource_id
+        offset = '/api/data/{0!s}/_search?q=hamlet'.format(resource_id)
         res = testapp.get(offset)
         assert res.status == 200
         out = json.loads(res.body)

--- a/ckan/ckan_nose_plugin.py
+++ b/ckan/ckan_nose_plugin.py
@@ -95,7 +95,7 @@ class CkanNose(Plugin):
 
     def finalize(self, report):
         if self.segments:
-            print 'Segments: %s' % self.segments
+            print 'Segments: {0!s}'.format(self.segments)
 
     def configure(self, settings, config):
         CkanNose.settings = settings

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -58,8 +58,7 @@ class _Helpers(object):
         self.functions = functions
 
         if allowed:
-            raise Exception('Template helper function(s) `%s` not defined'
-                            % ', '.join(allowed))
+            raise Exception('Template helper function(s) `{0!s}` not defined'.format(', '.join(allowed)))
 
         # extend helper functions with ones supplied by plugins
         extra_helpers = []
@@ -67,7 +66,7 @@ class _Helpers(object):
             helpers = plugin.get_helpers()
             for helper in helpers:
                 if helper in extra_helpers:
-                    raise Exception('overwritting extra helper %s' % helper)
+                    raise Exception('overwritting extra helper {0!s}'.format(helper))
                 extra_helpers.append(helper)
                 functions[helper] = helpers[helper]
         # logging
@@ -84,7 +83,7 @@ class _Helpers(object):
         ''' return the function/object requested '''
         if name in self.functions:
             if name in self.deprecated:
-                msg = 'Template helper function `%s` is deprecated' % name
+                msg = 'Template helper function `{0!s}` is deprecated'.format(name)
                 self.log.warn(msg)
             return self.functions[name]
         else:
@@ -119,7 +118,7 @@ def load_environment(global_conf, app_conf):
         if '.' in controller or ':' in controller:
             mycontroller = pkg_resources \
                 .EntryPoint \
-                .parse('x=%s' % controller).load(False)
+                .parse('x={0!s}'.format(controller)).load(False)
             self.controller_classes[controller] = mycontroller
             return mycontroller
         return find_controller_generic(self, controller)

--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -225,7 +225,7 @@ class I18nMiddleware(object):
             if qs:
                 # sort out weird encodings
                 #qs = urllib.quote(qs, '')
-                environ['CKAN_CURRENT_URL'] = '%s?%s' % (path_info, qs)
+                environ['CKAN_CURRENT_URL'] = '{0!s}?{1!s}'.format(path_info, qs)
             else:
                 environ['CKAN_CURRENT_URL'] = path_info
 
@@ -269,7 +269,7 @@ class PageCacheMiddleware(object):
                     return self.app(environ, start_response)
 
         # Make our cache key
-        key = 'page:%s?%s' % (environ['PATH_INFO'], environ['QUERY_STRING'])
+        key = 'page:{0!s}?{1!s}'.format(environ['PATH_INFO'], environ['QUERY_STRING'])
 
         # Try to connect if we don't have a connection. Doing this here
         # allows the redis server to be unavailable at times.

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -61,7 +61,7 @@ class ApiController(base.BaseController):
             # Call start_response manually instead of the parent __call__
             # because we want to end the request instead of continuing.
             response_msg = response_msg.encode('utf8')
-            body = '%i %s' % (response.status_int, response_msg)
+            body = '{0:d} {1!s}'.format(response.status_int, response_msg)
             start_response(body, response.headers.items())
             return [response_msg]
 
@@ -117,30 +117,29 @@ class ApiController(base.BaseController):
     def _finish_not_authz(self, extra_msg=None):
         response_data = _('Access denied')
         if extra_msg:
-            response_data = '%s - %s' % (response_data, extra_msg)
+            response_data = '{0!s} - {1!s}'.format(response_data, extra_msg)
         return self._finish(403, response_data, 'json')
 
     def _finish_not_found(self, extra_msg=None):
         response_data = _('Not found')
         if extra_msg:
-            response_data = '%s - %s' % (response_data, extra_msg)
+            response_data = '{0!s} - {1!s}'.format(response_data, extra_msg)
         return self._finish(404, response_data, 'json')
 
     def _finish_bad_request(self, extra_msg=None):
         response_data = _('Bad request')
         if extra_msg:
-            response_data = '%s - %s' % (response_data, extra_msg)
+            response_data = '{0!s} - {1!s}'.format(response_data, extra_msg)
         return self._finish(400, response_data, 'json')
 
     def _wrap_jsonp(self, callback, response_msg):
-        return '%s(%s);' % (callback, response_msg)
+        return '{0!s}({1!s});'.format(callback, response_msg)
 
     def _set_response_header(self, name, value):
         try:
             value = str(value)
         except Exception, inst:
-            msg = "Couldn't convert '%s' header value '%s' to string: %s" % \
-                (name, value, inst)
+            msg = "Couldn't convert '{0!s}' header value '{1!s}' to string: {2!s}".format(name, value, inst)
             raise Exception(msg)
         response.headers[name] = value
 
@@ -159,7 +158,7 @@ class ApiController(base.BaseController):
         try:
             function = get_action(logic_function)
         except KeyError:
-            log.error('Can\'t find logic function: %s' % logic_function)
+            log.error('Can\'t find logic function: {0!s}'.format(logic_function))
             return self._finish_bad_request(
                 _('Action name not known: %s') % logic_function)
 
@@ -180,12 +179,12 @@ class ApiController(base.BaseController):
             request_data = self._get_request_data(try_url_params=
                                                   side_effect_free)
         except ValueError, inst:
-            log.error('Bad request data: %s' % inst)
+            log.error('Bad request data: {0!s}'.format(inst))
             return self._finish_bad_request(
                 _('JSON Error: %s') % inst)
         if not isinstance(request_data, dict):
             # this occurs if request_data is blank
-            log.error('Bad request data - not dict: %r' % request_data)
+            log.error('Bad request data - not dict: {0!r}'.format(request_data))
             return self._finish_bad_request(
                 _('Bad request data: %s') %
                 'Request data JSON decoded to %r but '
@@ -198,7 +197,7 @@ class ApiController(base.BaseController):
             return_dict['success'] = True
             return_dict['result'] = result
         except DataError, e:
-            log.error('Format incorrect: %s - %s' % (e.error, request_data))
+            log.error('Format incorrect: {0!s} - {1!s}'.format(e.error, request_data))
             return_dict['error'] = {'__type': 'Integrity Error',
                                     'message': e.error,
                                     'data': request_data}
@@ -210,14 +209,14 @@ class ApiController(base.BaseController):
             return_dict['success'] = False
             
             if unicode(e):
-                return_dict['error']['message'] += u': %s' % e
+                return_dict['error']['message'] += u': {0!s}'.format(e)
 
             return self._finish(403, return_dict, content_type='json')
         except NotFound, e:
             return_dict['error'] = {'__type': 'Not Found Error',
                                     'message': _('Not found')}
             if unicode(e):
-                return_dict['error']['message'] += u': %s' % e
+                return_dict['error']['message'] += u': {0!s}'.format(e)
             return_dict['success'] = False
             return self._finish(404, return_dict, content_type='json')
         except ValidationError, e:
@@ -226,23 +225,23 @@ class ApiController(base.BaseController):
             return_dict['error'] = error_dict
             return_dict['success'] = False
             # CS nasty_string ignore
-            log.error('Validation error: %r' % str(e.error_dict))
+            log.error('Validation error: {0!r}'.format(str(e.error_dict)))
             return self._finish(409, return_dict, content_type='json')
         except search.SearchQueryError, e:
             return_dict['error'] = {'__type': 'Search Query Error',
-                                    'message': 'Search Query is invalid: %r' %
-                                    e.args}
+                                    'message': 'Search Query is invalid: {0!r}'.format(
+                                    e.args)}
             return_dict['success'] = False
             return self._finish(400, return_dict, content_type='json')
         except search.SearchError, e:
             return_dict['error'] = {'__type': 'Search Error',
-                                    'message': 'Search error: %r' % e.args}
+                                    'message': 'Search error: {0!r}'.format(e.args)}
             return_dict['success'] = False
             return self._finish(409, return_dict, content_type='json')
         except search.SearchIndexError, e:
             return_dict['error'] = {'__type': 'Search Index Error',
-                    'message': 'Unable to add package to search index: %s' %
-                    str(e)}
+                    'message': 'Unable to add package to search index: {0!s}'.format(
+                    str(e))}
             return_dict['success'] = False
             return self._finish(500, return_dict, content_type='json')
         return self._finish_ok(return_dict)
@@ -265,7 +264,7 @@ class ApiController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'api_version': ver,
                    'auth_user_obj': c.userobj}
-        log.debug('listing: %s' % context)
+        log.debug('listing: {0!s}'.format(context))
         action_map = {
             'revision': 'revision_list',
             'group': 'group_list',
@@ -310,7 +309,7 @@ class ApiController(base.BaseController):
                    'api_version': ver, 'auth_user_obj': c.userobj}
         data_dict = {'id': id, 'id2': id2, 'rel': subregister}
 
-        log.debug('show: %s' % context)
+        log.debug('show: {0!s}'.format(context))
 
         action = self._get_action_from_map(action_map, register, subregister)
         if not action:
@@ -342,7 +341,7 @@ class ApiController(base.BaseController):
 
         context = {'model': model, 'session': model.Session, 'user': c.user,
                    'api_version': ver, 'auth_user_obj': c.userobj}
-        log.debug('create: %s' % (context))
+        log.debug('create: {0!s}'.format((context)))
         try:
             request_data = self._get_request_data()
             data_dict = {'id': id, 'id2': id2, 'rel': subregister}
@@ -361,7 +360,7 @@ class ApiController(base.BaseController):
             response_data = action(context, data_dict)
             location = None
             if "id" in data_dict:
-                location = str('%s/%s' % (request.path.replace('package',
+                location = str('{0!s}/{1!s}'.format(request.path.replace('package',
                                                                'dataset'),
                                           data_dict.get("id")))
             return self._finish_ok(response_data,
@@ -372,10 +371,10 @@ class ApiController(base.BaseController):
             return self._finish_not_found(unicode(e))
         except ValidationError, e:
             # CS: nasty_string ignore
-            log.error('Validation error: %r' % str(e.error_dict))
+            log.error('Validation error: {0!r}'.format(str(e.error_dict)))
             return self._finish(409, e.error_dict, content_type='json')
         except DataError, e:
-            log.error('Format incorrect: %s - %s' % (e.error, request_data))
+            log.error('Format incorrect: {0!s} - {1!s}'.format(e.error, request_data))
             error_dict = {
                 'success': False,
                 'error': {'__type': 'Integrity Error',
@@ -383,8 +382,8 @@ class ApiController(base.BaseController):
                                     'data': request_data}}
             return self._finish(400, error_dict, content_type='json')
         except search.SearchIndexError:
-            log.error('Unable to add package to search index: %s' %
-                      request_data)
+            log.error('Unable to add package to search index: {0!s}'.format(
+                      request_data))
             return self._finish(500,
                                 _(u'Unable to add package to search index') %
                                 request_data)
@@ -404,7 +403,7 @@ class ApiController(base.BaseController):
 
         context = {'model': model, 'session': model.Session, 'user': c.user,
                    'api_version': ver, 'id': id, 'auth_user_obj': c.userobj}
-        log.debug('update: %s' % (context))
+        log.debug('update: {0!s}'.format((context)))
         try:
             request_data = self._get_request_data()
             data_dict = {'id': id, 'id2': id2, 'rel': subregister}
@@ -427,10 +426,10 @@ class ApiController(base.BaseController):
             return self._finish_not_found(unicode(e))
         except ValidationError, e:
             # CS: nasty_string ignore
-            log.error('Validation error: %r' % str(e.error_dict))
+            log.error('Validation error: {0!r}'.format(str(e.error_dict)))
             return self._finish(409, e.error_dict, content_type='json')
         except DataError, e:
-            log.error('Format incorrect: %s - %s' % (e.error, request_data))
+            log.error('Format incorrect: {0!s} - {1!s}'.format(e.error, request_data))
             error_dict = {
                 'success': False,
                 'error': {'__type': 'Integrity Error',
@@ -438,7 +437,7 @@ class ApiController(base.BaseController):
                                     'data': request_data}}
             return self._finish(400, error_dict, content_type='json')
         except search.SearchIndexError:
-            log.error('Unable to update search index: %s' % request_data)
+            log.error('Unable to update search index: {0!s}'.format(request_data))
             return self._finish(500, _(u'Unable to update search index') %
                                 request_data)
 
@@ -458,7 +457,7 @@ class ApiController(base.BaseController):
 
         data_dict = {'id': id, 'id2': id2, 'rel': subregister}
 
-        log.debug('delete %s/%s/%s/%s' % (register, id, subregister, id2))
+        log.debug('delete {0!s}/{1!s}/{2!s}/{3!s}'.format(register, id, subregister, id2))
 
         action = self._get_action_from_map(action_map, register, subregister)
         if not action:
@@ -474,12 +473,12 @@ class ApiController(base.BaseController):
             return self._finish_not_found(unicode(e))
         except ValidationError, e:
             # CS: nasty_string ignore
-            log.error('Validation error: %r' % str(e.error_dict))
+            log.error('Validation error: {0!r}'.format(str(e.error_dict)))
             return self._finish(409, e.error_dict, content_type='json')
 
     def search(self, ver=None, register=None):
 
-        log.debug('search %s params: %r' % (register, request.params))
+        log.debug('search {0!s} params: {1!r}'.format(register, request.params))
         if register == 'revision':
             since_time = None
             if 'since_id' in request.params:
@@ -497,7 +496,7 @@ class ApiController(base.BaseController):
                 try:
                     since_time = h.date_str_to_datetime(since_time_str)
                 except ValueError, inst:
-                    return self._finish_bad_request('ValueError: %s' % inst)
+                    return self._finish_bad_request('ValueError: {0!s}'.format(inst))
             else:
                 return self._finish_bad_request(
                     _("Missing search term ('since_id=UUID' or " +
@@ -510,7 +509,7 @@ class ApiController(base.BaseController):
                 params = MultiDict(self._get_search_params(request.params))
             except ValueError, e:
                 return self._finish_bad_request(
-                    _('Could not read parameters: %r' % e))
+                    _('Could not read parameters: {0!r}'.format(e)))
 
             # if using API v2, default to returning the package ID if
             # no field list is specified
@@ -627,10 +626,10 @@ class ApiController(base.BaseController):
         timing_cache_path = self._get_timing_cache_path()
         call_count = 0
         for t in range(0, period):
-            expr = '%s/%s*' % (
+            expr = '{0!s}/{1!s}*'.format(
                 timing_cache_path,
                 (datetime.datetime.now() -
-                 datetime.timedelta(0, t)).isoformat()[0:19],
+                 datetime.timedelta(0, t)).isoformat()[0:19]
             )
             call_count += len(glob.glob(expr))
         # Todo: Clear old records.
@@ -699,7 +698,7 @@ class ApiController(base.BaseController):
             response_data = dict(valid=not (group_exists(slug) or
                                  slug in disallowed))
             return self._finish_ok(response_data)
-        return self._finish_bad_request('Bad slug type: %s' % slugtype)
+        return self._finish_bad_request('Bad slug type: {0!s}'.format(slugtype))
 
     def dataset_autocomplete(self):
         q = request.params.get('incomplete', '')
@@ -786,7 +785,7 @@ class ApiController(base.BaseController):
         ''' translation strings for front end '''
         ckan_path = os.path.join(os.path.dirname(__file__), '..')
         source = os.path.abspath(os.path.join(ckan_path, 'public',
-                                 'base', 'i18n', '%s.js' % lang))
+                                 'base', 'i18n', '{0!s}.js'.format(lang)))
         response.headers['Content-Type'] = CONTENT_TYPES['json']
         if not os.path.exists(source):
             return '{}'
@@ -833,9 +832,9 @@ class ApiController(base.BaseController):
             else:
                 return entity
 
-        cls.log.debug('Retrieving request params: %r' % request.params)
-        cls.log.debug('Retrieving request POST: %r' % request.POST)
-        cls.log.debug('Retrieving request GET: %r' % request.GET)
+        cls.log.debug('Retrieving request params: {0!r}'.format(request.params))
+        cls.log.debug('Retrieving request POST: {0!r}'.format(request.POST))
+        cls.log.debug('Retrieving request GET: {0!r}'.format(request.GET))
         request_data = None
         if request.POST and request.content_type == 'multipart/form-data':
             request_data = dict(request.POST)
@@ -849,8 +848,7 @@ class ApiController(base.BaseController):
                 else:
                     request_data = urllib.unquote_plus(request.body)
             except Exception, inst:
-                msg = "Could not find the POST data: %r : %s" % \
-                      (request.POST, inst)
+                msg = "Could not find the POST data: {0!r} : {1!s}".format(request.POST, inst)
                 raise ValueError(msg)
 
         elif try_url_params and request.GET:
@@ -863,10 +861,10 @@ class ApiController(base.BaseController):
                 else:
                     request_data = None
             except Exception, inst:
-                msg = "Could not extract request body data: %s" % \
-                      (inst)
+                msg = "Could not extract request body data: {0!s}".format( \
+                      (inst))
                 raise ValueError(msg)
-            cls.log.debug('Retrieved request body: %r' % request.body)
+            cls.log.debug('Retrieved request body: {0!r}'.format(request.body))
             if not request_data:
                 if not try_url_params:
                     msg = "No request body data"
@@ -889,5 +887,5 @@ class ApiController(base.BaseController):
                 # if val is str then assume it is ascii, since json converts
                 # utf8 encoded JSON to unicode
                 request_data[key] = make_unicode(val)
-        cls.log.debug('Request data extracted: %r' % request_data)
+        cls.log.debug('Request data extracted: {0!r}'.format(request_data))
         return request_data

--- a/ckan/controllers/error.py
+++ b/ckan/controllers/error.py
@@ -51,5 +51,5 @@ class ErrorController(BaseController):
         """Call Paste's FileApp (a WSGI application) to serve the file
         at the specified path
         """
-        request.environ['PATH_INFO'] = '/%s' % path
+        request.environ['PATH_INFO'] = '/{0!s}'.format(path)
         return forward(PkgResourcesParser('pylons', 'pylons'))

--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -170,7 +170,7 @@ class FeedController(base.BaseController):
 
         data_dict, params = self._parse_url_params()
         key = 'owner_org' if is_org else 'groups'
-        data_dict['fq'] = '%s:"%s"' % (key, obj_dict['id'],)
+        data_dict['fq'] = '{0!s}:"{1!s}"'.format(key, obj_dict['id'])
         group_type = 'organization'
         if not is_org:
             group_type = 'group'
@@ -188,23 +188,20 @@ class FeedController(base.BaseController):
                                   action=group_type,
                                   id=obj_dict['name'])
 
-        guid = _create_atom_id(u'/feeds/group/%s.atom' %
-                               obj_dict['name'])
+        guid = _create_atom_id(u'/feeds/group/{0!s}.atom'.format(
+                               obj_dict['name']))
         alternate_url = self._alternate_url(params, groups=obj_dict['name'])
-        desc = u'Recently created or updated datasets on %s by group: "%s"' %\
-            (g.site_title, obj_dict['title'])
-        title = u'%s - Group: "%s"' %\
-            (g.site_title, obj_dict['title'])
+        desc = u'Recently created or updated datasets on {0!s} by group: "{1!s}"'.format(g.site_title, obj_dict['title'])
+        title = u'{0!s} - Group: "{1!s}"'.format(g.site_title, obj_dict['title'])
 
         if is_org:
-            guid = _create_atom_id(u'/feeds/organization/%s.atom' %
-                                   obj_dict['name'])
+            guid = _create_atom_id(u'/feeds/organization/{0!s}.atom'.format(
+                                   obj_dict['name']))
             alternate_url = self._alternate_url(params,
                                                 organization=obj_dict['name'])
             desc = u'Recently created or  updated datasets on %s '\
                 'by organization: "%s"' % (g.site_title, obj_dict['title'])
-            title = u'%s - Organization: "%s"' %\
-                (g.site_title, obj_dict['title'])
+            title = u'{0!s} - Organization: "{1!s}"'.format(g.site_title, obj_dict['title'])
 
         return self.output_feed(results,
                                 feed_title=title,
@@ -237,7 +234,7 @@ class FeedController(base.BaseController):
 
     def tag(self, id):
         data_dict, params = self._parse_url_params()
-        data_dict['fq'] = 'tags:"%s"' % id
+        data_dict['fq'] = 'tags:"{0!s}"'.format(id)
 
         item_count, results = _package_search(data_dict)
 
@@ -256,14 +253,13 @@ class FeedController(base.BaseController):
         alternate_url = self._alternate_url(params, tags=id)
 
         return self.output_feed(results,
-                                feed_title=u'%s - Tag: "%s"' %
-                                (g.site_title, id),
+                                feed_title=u'{0!s} - Tag: "{1!s}"'.format(g.site_title, id),
                                 feed_description=u'Recently created or '
                                 'updated datasets on %s by tag: "%s"' %
                                 (g.site_title, id),
                                 feed_link=alternate_url,
                                 feed_guid=_create_atom_id
-                                (u'/feeds/tag/%s.atom' % id),
+                                (u'/feeds/tag/{0!s}.atom'.format(id)),
                                 feed_url=feed_url,
                                 navigation_urls=navigation_urls)
 
@@ -304,7 +300,7 @@ class FeedController(base.BaseController):
             if param not in ['q', 'page', 'sort'] \
                     and len(value) and not param.startswith('_'):
                 search_params[param] = value
-                fq += ' %s:"%s"' % (param, value)
+                fq += ' {0!s}:"{1!s}"'.format(param, value)
 
         page = self._get_page_number(request.params)
 
@@ -335,7 +331,7 @@ class FeedController(base.BaseController):
         alternate_url = self._alternate_url(request.params)
 
         return self.output_feed(results,
-                                feed_title=u'%s - Custom query' % g.site_title,
+                                feed_title=u'{0!s} - Custom query'.format(g.site_title),
                                 feed_description=u'Recently created or updated'
                                 ' datasets on %s. Custom query: \'%s\'' %
                                 (g.site_title, q),
@@ -376,7 +372,7 @@ class FeedController(base.BaseController):
                 description=pkg.get('notes', ''),
                 updated=h.date_str_to_datetime(pkg.get('metadata_modified')),
                 published=h.date_str_to_datetime(pkg.get('metadata_created')),
-                unique_id=_create_atom_id(u'/dataset/%s' % pkg['id']),
+                unique_id=_create_atom_id(u'/dataset/{0!s}'.format(pkg['id'])),
                 author_name=pkg.get('author', ''),
                 author_email=pkg.get('author_email', ''),
                 categories=[t['name'] for t in pkg.get('tags', [])],

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -205,9 +205,9 @@ class GroupController(base.BaseController):
         q = c.q = request.params.get('q', '')
         # Search within group
         if c.group_dict.get('is_organization'):
-            q += ' owner_org:"%s"' % c.group_dict.get('id')
+            q += ' owner_org:"{0!s}"'.format(c.group_dict.get('id'))
         else:
-            q += ' groups:"%s"' % c.group_dict.get('name')
+            q += ' groups:"{0!s}"'.format(c.group_dict.get('name'))
 
         c.description_formatted = h.render_markdown(c.group_dict.get('description'))
 
@@ -268,7 +268,7 @@ class GroupController(base.BaseController):
                         and len(value) and not param.startswith('_'):
                     if not param.startswith('ext_'):
                         c.fields.append((param, value))
-                        q += ' %s: "%s"' % (param, value)
+                        q += ' {0!s}: "{1!s}"'.format(param, value)
                     else:
                         search_extras[param] = value
 
@@ -339,7 +339,7 @@ class GroupController(base.BaseController):
             c.search_facets = query['search_facets']
             c.search_facets_limits = {}
             for facet in c.facets.keys():
-                limit = int(request.params.get('_%s_limit' % facet,
+                limit = int(request.params.get('_{0!s}_limit'.format(facet),
                                                g.facets_default_number))
                 c.search_facets_limits[facet] = limit
             c.page.items = query['results']
@@ -556,7 +556,7 @@ class GroupController(base.BaseController):
             if id != group['name']:
                 self._force_reindex(group)
 
-            h.redirect_to('%s_read' % group['type'], id=group['name'])
+            h.redirect_to('{0!s}_read'.format(group['type']), id=group['name'])
         except NotAuthorized:
             abort(401, _('Unauthorized to read group %s') % id)
         except NotFound, e:
@@ -769,14 +769,14 @@ class GroupController(base.BaseController):
                 if dayAge >= dayHorizon:
                     break
                 if revision_dict['message']:
-                    item_title = u'%s' % revision_dict['message'].\
-                        split('\n')[0]
+                    item_title = u'{0!s}'.format(revision_dict['message'].\
+                        split('\n')[0])
                 else:
-                    item_title = u'%s' % revision_dict['id']
+                    item_title = u'{0!s}'.format(revision_dict['id'])
                 item_link = h.url_for(controller='revision', action='read',
                                       id=revision_dict['id'])
                 item_description = _('Log message: ')
-                item_description += '%s' % (revision_dict['message'] or '')
+                item_description += '{0!s}'.format((revision_dict['message'] or ''))
                 item_author_name = revision_dict['author']
                 item_pubdate = revision_date
                 feed.add_item(

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -194,7 +194,7 @@ class HomeController(base.BaseController):
             for cache_name in wui_caches:
                 cache_ = cache.get_cache(cache_name, type='dbm')
                 cache_.clear()
-            return 'Cleared caches: %s' % ', '.join(wui_caches)
+            return 'Cleared caches: {0!s}'.format(', '.join(wui_caches))
 
     def cors_options(self, url=None):
         # just return 200 OK and empty data

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -184,7 +184,7 @@ class PackageController(base.BaseController):
             params = params_nosort[:]
 
             if fields:
-                sort_string = ', '.join('%s %s' % f for f in fields)
+                sort_string = ', '.join('{0!s} {1!s}'.format(*f) for f in fields)
                 params.append(('sort', sort_string))
             return search_url(params, package_type)
 
@@ -214,7 +214,7 @@ class PackageController(base.BaseController):
                         and len(value) and not param.startswith('_'):
                     if not param.startswith('ext_'):
                         c.fields.append((param, value))
-                        fq += ' %s:"%s"' % (param, value)
+                        fq += ' {0!s}:"{1!s}"'.format(param, value)
                         if param not in c.fields_grouped:
                             c.fields_grouped[param] = [value]
                         else:
@@ -289,12 +289,12 @@ class PackageController(base.BaseController):
         c.search_facets_limits = {}
         for facet in c.search_facets.keys():
             try:
-                limit = int(request.params.get('_%s_limit' % facet,
+                limit = int(request.params.get('_{0!s}_limit'.format(facet),
                                                g.facets_default_number))
             except ValueError:
                 abort(400, _('Parameter "{parameter_name}" is not '
                              'an integer').format(
-                                 parameter_name='_%s_limit' % facet
+                                 parameter_name='_{0!s}_limit'.format(facet)
                              ))
             c.search_facets_limits[facet] = limit
 
@@ -359,7 +359,7 @@ class PackageController(base.BaseController):
             if not ctype:
                 # An unknown format, we'll carry on in case it is a
                 # revision specifier and re-constitute the original id
-                id = "%s.%s" % (id, format)
+                id = "{0!s}.{1!s}".format(id, format)
                 ctype, format = "text/html; charset=utf-8", "html"
         else:
             ctype, format = self._content_type_from_accept()
@@ -487,14 +487,14 @@ class PackageController(base.BaseController):
                 if dayAge >= dayHorizon:
                     break
                 if revision_dict['message']:
-                    item_title = u'%s' % revision_dict['message'].\
-                        split('\n')[0]
+                    item_title = u'{0!s}'.format(revision_dict['message'].\
+                        split('\n')[0])
                 else:
-                    item_title = u'%s' % revision_dict['id']
+                    item_title = u'{0!s}'.format(revision_dict['id'])
                 item_link = h.url_for(controller='revision', action='read',
                                       id=revision_dict['id'])
                 item_description = _('Log message: ')
-                item_description += '%s' % (revision_dict['message'] or '')
+                item_description += '{0!s}'.format((revision_dict['message'] or ''))
                 item_author_name = revision_dict['author']
                 item_pubdate = revision_date
                 feed.add_item(
@@ -1032,7 +1032,7 @@ class PackageController(base.BaseController):
         '''
         assert action in ('new', 'edit')
         url = request.params.get('return_to') or \
-            config.get('package_%s_return_url' % action)
+            config.get('package_{0!s}_return_url'.format(action))
         if url:
             url = url.replace('<NAME>', pkgname)
         else:
@@ -1128,7 +1128,7 @@ class PackageController(base.BaseController):
             c.package['isopen'] = False
 
         # TODO: find a nicer way of doing this
-        c.datastore_api = '%s/api/action' % config.get('ckan.site_url', '').rstrip('/')
+        c.datastore_api = '{0!s}/api/action'.format(config.get('ckan.site_url', '').rstrip('/'))
 
         c.related_count = c.pkg.related_count
 

--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -97,16 +97,16 @@ class RevisionController(base.BaseController):
                                         'date_updated':
                                     transition += ':date_updated'
                                     break
-                    indication = "%s:%s" % (package.name, transition)
+                    indication = "{0!s}:{1!s}".format(package.name, transition)
                     package_indications.append(indication)
-                pkgs = u'[%s]' % ' '.join(package_indications)
-                item_title = u'r%s ' % (revision.id)
+                pkgs = u'[{0!s}]'.format(' '.join(package_indications))
+                item_title = u'r{0!s} '.format((revision.id))
                 item_title += pkgs
                 if revision.message:
-                    item_title += ': %s' % (revision.message or '')
+                    item_title += ': {0!s}'.format((revision.message or ''))
                 item_link = h.url_for(controller='revision', action='read', id=revision.id)
                 item_description = _('Datasets affected: %s.\n') % pkgs
-                item_description += '%s' % (revision.message or '')
+                item_description += '{0!s}'.format((revision.message or ''))
                 item_author_name = revision.author
                 item_pubdate = revision.timestamp
                 feed.add_item(

--- a/ckan/controllers/storage.py
+++ b/ckan/controllers/storage.py
@@ -261,7 +261,7 @@ class StorageAPIController(BaseController):
         if storage_backend in ['google', 's3']:
             if not label.startswith("/"):
                 label = "/" + label
-            url = "https://%s%s" % (
+            url = "https://{0!s}{1!s}".format(
                 self.ofs.conn.calling_format.build_host(
                     self.ofs.conn.server_name(), bucket), label)
         else:
@@ -338,7 +338,7 @@ class StorageAPIController(BaseController):
         fields = [{
             'name': self.ofs.conn.provider.metadata_prefix + 'uploaded-by',
             'value': c.userobj.id}]
-        conditions = ['{"%s": "%s"}' % (x['name'], x['value']) for x in
+        conditions = ['{{"{0!s}": "{1!s}"}}'.format(x['name'], x['value']) for x in
                       fields]
         # In FF redirect to this breaks js upload as FF attempts to open file
         # (presumably because mimetype = javascript) and this stops js

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -504,7 +504,7 @@ class UserController(base.BaseController):
             except DataError:
                 h.flash_error(_(u'Integrity Error'))
             except ValidationError, e:
-                h.flash_error(u'%r' % e.error_dict)
+                h.flash_error(u'{0!r}'.format(e.error_dict))
             except ValueError, ve:
                 h.flash_error(unicode(ve))
 

--- a/ckan/include/rcssmin.py
+++ b/ckan/include/rcssmin.py
@@ -108,7 +108,7 @@ def _make_cssmin(python_only=False):
 
     unicoded = r'[0-9a-fA-F]{1,6}(?:[\040\n\t\f]|\r\n?)?'
     escaped = r'[^\n\r\f0-9a-fA-F]'
-    escape = r'(?:\\(?:%(unicoded)s|%(escaped)s))' % locals()
+    escape = r'(?:\\(?:{unicoded!s}|{escaped!s}))'.format(**locals())
 
     nmchar = r'[^\000-\054\056\057\072-\100\133-\136\140\173-\177]'
     #nmstart = r'[^\000-\100\133-\136\140\173-\177]'
@@ -124,20 +124,20 @@ def _make_cssmin(python_only=False):
     string1 = \
         r'(?:\047[^\047\\\r\n\f]*(?:\\[^\r\n\f][^\047\\\r\n\f]*)*\047)'
     string2 = r'(?:"[^"\\\r\n\f]*(?:\\[^\r\n\f][^"\\\r\n\f]*)*")'
-    strings = r'(?:%s|%s)' % (string1, string2)
+    strings = r'(?:{0!s}|{1!s})'.format(string1, string2)
 
     nl_string1 = \
         r'(?:\047[^\047\\\r\n\f]*(?:\\(?:[^\r]|\r\n?)[^\047\\\r\n\f]*)*\047)'
     nl_string2 = r'(?:"[^"\\\r\n\f]*(?:\\(?:[^\r]|\r\n?)[^"\\\r\n\f]*)*")'
-    nl_strings = r'(?:%s|%s)' % (nl_string1, nl_string2)
+    nl_strings = r'(?:{0!s}|{1!s})'.format(nl_string1, nl_string2)
 
     uri_nl_string1 = r'(?:\047[^\047\\]*(?:\\(?:[^\r]|\r\n?)[^\047\\]*)*\047)'
     uri_nl_string2 = r'(?:"[^"\\]*(?:\\(?:[^\r]|\r\n?)[^"\\]*)*")'
-    uri_nl_strings = r'(?:%s|%s)' % (uri_nl_string1, uri_nl_string2)
+    uri_nl_strings = r'(?:{0!s}|{1!s})'.format(uri_nl_string1, uri_nl_string2)
 
-    nl_escaped = r'(?:\\%(nl)s)' % locals()
+    nl_escaped = r'(?:\\{nl!s})'.format(**locals())
 
-    space = r'(?:%(spacechar)s|%(comment)s)' % locals()
+    space = r'(?:{spacechar!s}|{comment!s})'.format(**locals())
 
     ie7hack = r'(?:>/\*\*/)'
 
@@ -292,7 +292,7 @@ def _make_cssmin(python_only=False):
             fn_open,                            # {
             fn_close,                           # }
             lambda g: g(11),                    # string
-            lambda g: 'url(%s)' % uri_space_sub(uri_space_subber, g(12)),
+            lambda g: 'url({0!s})'.format(uri_space_sub(uri_space_subber, g(12))),
                                                 # url(...)
             fn_media,                           # @media
             None,

--- a/ckan/include/rjsmin.py
+++ b/ckan/include/rjsmin.py
@@ -99,21 +99,21 @@ def _make_jsmin(python_only=False):
     string1 = \
         r'(?:\047[^\047\\\r\n]*(?:\\(?:[^\r\n]|\r?\n|\r)[^\047\\\r\n]*)*\047)'
     string2 = r'(?:"[^"\\\r\n]*(?:\\(?:[^\r\n]|\r?\n|\r)[^"\\\r\n]*)*")'
-    strings = r'(?:%s|%s)' % (string1, string2)
+    strings = r'(?:{0!s}|{1!s})'.format(string1, string2)
 
     charclass = r'(?:\[[^\\\]\r\n]*(?:\\[^\r\n][^\\\]\r\n]*)*\])'
     nospecial = r'[^/\\\[\r\n]'
-    regex = r'(?:/(?![\r\n/*])%s*(?:(?:\\[^\r\n]|%s)%s*)*/)' % (
+    regex = r'(?:/(?![\r\n/*]){0!s}*(?:(?:\\[^\r\n]|{1!s}){2!s}*)*/)'.format(
         nospecial, charclass, nospecial
     )
-    space = r'(?:%s|%s)' % (space_chars, space_comment)
-    newline = r'(?:%s?[\r\n])' % line_comment
+    space = r'(?:{0!s}|{1!s})'.format(space_chars, space_comment)
+    newline = r'(?:{0!s}?[\r\n])'.format(line_comment)
 
     def fix_charclass(result):
         """ Fixup string of chars to fit into a regex char class """
         pos = result.find('-')
         if pos >= 0:
-            result = r'%s%s-' % (result[:pos], result[pos + 1:])
+            result = r'{0!s}{1!s}-'.format(result[:pos], result[pos + 1:])
 
         def sequentize(string):
             """
@@ -132,14 +132,14 @@ def _make_jsmin(python_only=False):
                     first = last = char
             if last is not None:
                 result.append((first, last))
-            return ''.join(['%s%s%s' % (
+            return ''.join(['{0!s}{1!s}{2!s}'.format(
                 chr(first),
                 last > first + 1 and '-' or '',
                 last != first and chr(last) or ''
             ) for first, last in result])
 
         return _re.sub(r'([\000-\040\047])', # for better portability
-            lambda m: '\\%03o' % ord(m.group(1)), (sequentize(result)
+            lambda m: '\\{0:03o}'.format(ord(m.group(1))), (sequentize(result)
                 .replace('\\', '\\\\')
                 .replace('[', '\\[')
                 .replace(']', '\\]')
@@ -152,7 +152,7 @@ def _make_jsmin(python_only=False):
         result = ''.join([
             chr(c) for c in xrange(127) if not match(chr(c))
         ])
-        return '[^%s]' % fix_charclass(result)
+        return '[^{0!s}]'.format(fix_charclass(result))
 
     def not_id_literal_(keep):
         """ Make negated id_literal like char class """
@@ -160,11 +160,11 @@ def _make_jsmin(python_only=False):
         result = ''.join([
             chr(c) for c in xrange(127) if not match(chr(c))
         ])
-        return r'[%s]' % fix_charclass(result)
+        return r'[{0!s}]'.format(fix_charclass(result))
 
     not_id_literal = not_id_literal_(r'[a-zA-Z0-9_$]')
     preregex1 = r'[(,=:\[!&|?{};\r\n]'
-    preregex2 = r'%(not_id_literal)sreturn' % locals()
+    preregex2 = r'{not_id_literal!s}return'.format(**locals())
 
     id_literal = id_literal_(r'[a-zA-Z0-9_$]')
     id_literal_open = id_literal_(r'[a-zA-Z0-9_${\[(+-]')
@@ -216,7 +216,7 @@ def _make_jsmin(python_only=False):
         :Return: Minified script
         :Rtype: ``str``
         """
-        return space_sub(space_subber, '\n%s\n' % script).strip()
+        return space_sub(space_subber, '\n{0!s}\n'.format(script)).strip()
 
     return jsmin
 
@@ -281,7 +281,7 @@ def jsmin_for_posers(script):
         r'\014\016-\040]|(?:/\*[^*]*\*+(?:[^/*][^*]*\*+)*/)))+(?=--)|(?:[\00'
         r'0-\011\013\014\016-\040]|(?:/\*[^*]*\*+(?:[^/*][^*]*\*+)*/))+|(?:('
         r'?:(?://[^\r\n]*)?[\r\n])(?:[\000-\011\013\014\016-\040]|(?:/\*[^*]'
-        r'*\*+(?:[^/*][^*]*\*+)*/))*)+', subber, '\n%s\n' % script
+        r'*\*+(?:[^/*][^*]*\*+)*/))*)+', subber, '\n{0!s}\n'.format(script)
     ).strip()
 
 

--- a/ckan/lib/activity_streams.py
+++ b/ckan/lib/activity_streams.py
@@ -13,20 +13,17 @@ from ckan.common import _
 # etc.
 
 def get_snippet_actor(activity, detail):
-    return literal('''<span class="actor">%s</span>'''
-        % (h.linked_user(activity['user_id'], 0, 30))
+    return literal('''<span class="actor">{0!s}</span>'''.format((h.linked_user(activity['user_id'], 0, 30)))
         )
 
 def get_snippet_user(activity, detail):
-    return literal('''<span>%s</span>'''
-        % (h.linked_user(activity['object_id'], 0, 20))
+    return literal('''<span>{0!s}</span>'''.format((h.linked_user(activity['object_id'], 0, 20)))
         )
 
 def get_snippet_dataset(activity, detail):
     data = activity['data']
     link = h.dataset_link(data.get('package') or data.get('dataset'))
-    return literal('''<span>%s</span>'''
-        % (link)
+    return literal('''<span>{0!s}</span>'''.format((link))
         )
 
 def get_snippet_tag(activity, detail):
@@ -34,15 +31,14 @@ def get_snippet_tag(activity, detail):
 
 def get_snippet_group(activity, detail):
     link = h.group_link(activity['data']['group'])
-    return literal('''<span>%s</span>'''
-        % (link)
+    return literal('''<span>{0!s}</span>'''.format((link))
         )
 
 def get_snippet_organization(activity, detail):
     return h.organization_link(activity['data']['group'])
 
 def get_snippet_extra(activity, detail):
-    return '"%s"' % detail['data']['package_extra']['key']
+    return '"{0!s}"'.format(detail['data']['package_extra']['key'])
 
 def get_snippet_resource(activity, detail):
     return h.resource_link(detail['data']['resource'],
@@ -249,7 +245,7 @@ def activity_list_to_html(context, activity_stream, extra_vars):
                 if object_type == 'PackageExtra':
                     object_type = 'package_extra'
 
-                new_activity_type = '%s %s' % (detail['activity_type'],
+                new_activity_type = '{0!s} {1!s}'.format(detail['activity_type'],
                                             object_type.lower())
                 if new_activity_type in activity_stream_string_functions:
                     activity_type = new_activity_type

--- a/ckan/lib/activity_streams_session_extension.py
+++ b/ckan/lib/activity_streams_session_extension.py
@@ -62,7 +62,7 @@ class DatasetActivitySessionExtension(SessionExtension):
             # revision.author is their IP address. Just log them as 'not logged
             # in' rather than logging their IP address.
             user_id = 'not logged in'
-        logger.debug('user_id: %s' % user_id)
+        logger.debug('user_id: {0!s}'.format(user_id))
 
         # The top-level objects that we will append to the activity table. The
         # keys here are package IDs, and the values are model.activity:Activity
@@ -79,14 +79,14 @@ class DatasetActivitySessionExtension(SessionExtension):
         # logged as changed packages.
         logger.debug("Looking for new packages...")
         for obj in object_cache['new']:
-            logger.debug("Looking at object %s" % obj)
+            logger.debug("Looking at object {0!s}".format(obj))
             activity = activity_stream_item(obj, 'new', revision, user_id)
             if activity is None:
                 continue
             # If the object returns an activity stream item we know that the
             # object is a package.
             logger.debug("Looks like this object is a package")
-            logger.debug("activity: %s" % activity)
+            logger.debug("activity: {0!s}".format(activity))
 
             # Don't create activities for private datasets.
             if obj.private:
@@ -96,7 +96,7 @@ class DatasetActivitySessionExtension(SessionExtension):
 
             activity_detail = activity_stream_detail(obj, activity.id, "new")
             if activity_detail is not None:
-                logger.debug("activity_detail: %s" % activity_detail)
+                logger.debug("activity_detail: {0!s}".format(activity_detail))
                 activity_details[activity.id] = [activity_detail]
 
         # Now process other objects.
@@ -104,7 +104,7 @@ class DatasetActivitySessionExtension(SessionExtension):
         for activity_type in ('new', 'changed', 'deleted'):
             objects = object_cache[activity_type]
             for obj in objects:
-                logger.debug("Looking at %s object %s" % (activity_type, obj))
+                logger.debug("Looking at {0!s} object {1!s}".format(activity_type, obj))
 
                 if not hasattr(obj,"id"):
                     logger.debug("Object has no id, skipping...")
@@ -118,7 +118,7 @@ class DatasetActivitySessionExtension(SessionExtension):
 
                 try:
                     related_packages = obj.related_packages()
-                    logger.debug("related_packages: %s" % related_packages)
+                    logger.debug("related_packages: {0!s}".format(related_packages))
                 except (AttributeError, TypeError):
                     logger.debug("Object did not have a suitable "
                             "related_packages() method, skipping it.")
@@ -137,11 +137,11 @@ class DatasetActivitySessionExtension(SessionExtension):
                         activity = activity_stream_item(package, "changed",
                                 revision, user_id)
                         if activity is None: continue
-                    logger.debug("activity: %s" % activity)
+                    logger.debug("activity: {0!s}".format(activity))
 
                     activity_detail = activity_stream_detail(obj, activity.id,
                             activity_type)
-                    logger.debug("activity_detail: %s" % activity_detail)
+                    logger.debug("activity_detail: {0!s}".format(activity_detail))
                     if activity_detail is not None:
                         if not package.id in activities:
                             activities[package.id] = activity
@@ -152,14 +152,12 @@ class DatasetActivitySessionExtension(SessionExtension):
                             activity_details[activity.id] =  [activity_detail]
 
         for key, activity in activities.items():
-            logger.debug("Emitting activity: %s %s"
-                    % (activity.id, activity.activity_type))
+            logger.debug("Emitting activity: {0!s} {1!s}".format(activity.id, activity.activity_type))
             session.add(activity)
 
         for key, activity_detail_list in activity_details.items():
             for activity_detail_obj in activity_detail_list:
-                logger.debug("Emitting activity detail: %s %s %s"
-                        % (activity_detail_obj.activity_id,
+                logger.debug("Emitting activity detail: {0!s} {1!s} {2!s}".format(activity_detail_obj.activity_id,
                             activity_detail_obj.activity_type,
                             activity_detail_obj.object_type))
                 session.add(activity_detail_obj)

--- a/ckan/lib/alphabet_paginate.py
+++ b/ckan/lib/alphabet_paginate.py
@@ -118,7 +118,7 @@ class AlphaPage(object):
                 attribute = column.next()['expr']
             if self.item_count >= self.paging_threshold:
                 if self.page != self.other_text:
-                    query = query.filter(attribute.ilike(u'%s%%' % self.page))
+                    query = query.filter(attribute.ilike(u'{0!s}%'.format(self.page)))
                 else:
                     # regexp search
                     query = query.filter(attribute.op('~')(u'^[^a-zA-Z].*'))

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -90,11 +90,11 @@ def set_global(key, value):
     model.set_system_info('ckan.config_update', str(time.time()))
     # update the config
     config[key] = value
-    log.info('config `%s` set to `%s`' % (key, value))
+    log.info('config `{0!s}` set to `{1!s}`'.format(key, value))
 
 def delete_global(key):
     model.delete_system_info(key)
-    log.info('config `%s` deleted' % (key))
+    log.info('config `{0!s}` deleted'.format((key)))
 
 def get_globals_key(key):
     # create our globals key
@@ -125,11 +125,11 @@ def reset():
         if key not in _CONFIG_CACHE:
             _CONFIG_CACHE[key] = config_value
         if value is not None:
-            log.debug('config `%s` set to `%s` from db' % (key, value))
+            log.debug('config `{0!s}` set to `{1!s}` from db'.format(key, value))
         else:
             value = _CONFIG_CACHE[key]
             if value:
-                log.debug('config `%s` set to `%s` from config' % (key, value))
+                log.debug('config `{0!s}` set to `{1!s}` from config'.format(key, value))
             else:
                 value = default
         setattr(app_globals, get_globals_key(key), value)

--- a/ckan/lib/auth_tkt.py
+++ b/ckan/lib/auth_tkt.py
@@ -66,7 +66,7 @@ def make_plugin(secret=None,
     if secretfile:
         secretfile = os.path.abspath(os.path.expanduser(secretfile))
         if not os.path.exists(secretfile):
-            raise ValueError("No such 'secretfile': %s" % secretfile)
+            raise ValueError("No such 'secretfile': {0!s}".format(secretfile))
         secret = open(secretfile).read().strip()
     if timeout:
         timeout = int(timeout)

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -77,7 +77,7 @@ def render_snippet(template_name, **kw):
     cache_force = kw.pop('cache_force', None)
     output = render(template_name, extra_vars=kw, cache_force=cache_force,
                     renderer='snippet')
-    output = '\n<!-- Snippet %s start -->\n%s\n<!-- Snippet %s end -->\n' % (
+    output = '\n<!-- Snippet {0!s} start -->\n{1!s}\n<!-- Snippet {2!s} end -->\n'.format(
         template_name, output, template_name)
     return literal(output)
 
@@ -130,7 +130,7 @@ def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
         except render_.TemplateNotFound:
             raise
 
-        log.debug('rendering %s [%s]' % (template_path, template_type))
+        log.debug('rendering {0!s} [{1!s}]'.format(template_path, template_type))
         if config.get('debug'):
             context_vars = globs.get('c')
             if context_vars:
@@ -202,7 +202,7 @@ def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
         try:
             cache_expire = int(config.get('ckan.cache_expires', 0))
             response.headers["Cache-Control"] += \
-                ", max-age=%s, must-revalidate" % cache_expire
+                ", max-age={0!s}, must-revalidate".format(cache_expire)
         except ValueError:
             pass
     else:
@@ -217,8 +217,7 @@ def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
                                loader_class=loader_class)
     except ckan.exceptions.CkanUrlException, e:
         raise ckan.exceptions.CkanUrlException(
-            '\nAn Exception has been raised for template %s\n%s' %
-            (template_name, e.message))
+            '\nAn Exception has been raised for template {0!s}\n{1!s}'.format(template_name, e.message))
     except render_.TemplateNotFound:
         raise
 
@@ -373,7 +372,7 @@ class BaseController(WSGIController):
             self._set_cors()
         r_time = time.time() - c.__timer
         url = request.environ['CKAN_CURRENT_URL'].split('?')[0]
-        log.info(' %s render time %.3f seconds' % (url, r_time))
+        log.info(' {0!s} render time {1:.3f} seconds'.format(url, r_time))
 
     def _set_cors(self):
         '''
@@ -413,7 +412,7 @@ class BaseController(WSGIController):
                 apikey = ''
         if not apikey:
             return None
-        self.log.debug("Received API Key: %s" % apikey)
+        self.log.debug("Received API Key: {0!s}".format(apikey))
         apikey = unicode(apikey)
         query = model.Session.query(model.User)
         user = query.filter_by(apikey=apikey).first()

--- a/ckan/lib/celery_app.py
+++ b/ckan/lib/celery_app.py
@@ -44,7 +44,7 @@ for entry_point in iter_entry_points(group='ckan.celery_task'):
             entry_point.load()()
         )
     except VersionConflict, e:
-        error = 'ERROR in entry point load: %s %s' % (entry_point, e)
+        error = 'ERROR in entry point load: {0!s} {1!s}'.format(entry_point, e)
         log.critical(error)
         pass
 

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -52,7 +52,7 @@ def parse_db_config(config_key='sqlalchemy.url'):
     ]
     db_details_match = re.match(''.join(regex), url)
     if not db_details_match:
-        raise Exception('Could not extract db details from url: %r' % url)
+        raise Exception('Could not extract db details from url: {0!r}'.format(url))
     db_details = db_details_match.groupdict()
     return db_details
 
@@ -78,7 +78,7 @@ def query_yes_no(question, default="yes"):
     elif default == "no":
         prompt = " [y/N] "
     else:
-        raise ValueError("invalid default answer: '%s'" % default)
+        raise ValueError("invalid default answer: '{0!s}'".format(default))
 
     while 1:
         sys.stdout.write(question + prompt)
@@ -132,8 +132,8 @@ class CkanCommand(paste.script.command.Command):
             config_source = 'default value'
 
         if not os.path.exists(self.filename):
-            msg = 'Config file not found: %s' % self.filename
-            msg += '\n(Given by: %s)' % config_source
+            msg = 'Config file not found: {0!s}'.format(self.filename)
+            msg += '\n(Given by: {0!s})'.format(config_source)
             raise self.BadCommand(msg)
 
         fileConfig(self.filename)
@@ -258,7 +258,7 @@ class ManageDb(CkanCommand):
         elif cmd == 'migrate-filestore':
             self.migrate_filestore()
         else:
-            print 'Command %s not recognized' % cmd
+            print 'Command {0!s} not recognized'.format(cmd)
             sys.exit(1)
 
     def _get_db_config(self):
@@ -267,41 +267,41 @@ class ManageDb(CkanCommand):
     def _get_postgres_cmd(self, command):
         self.db_details = self._get_db_config()
         if self.db_details.get('db_type') not in ('postgres', 'postgresql'):
-            raise AssertionError('Expected postgres database - not %r' % self.db_details.get('db_type'))
+            raise AssertionError('Expected postgres database - not {0!r}'.format(self.db_details.get('db_type')))
         pg_cmd = command
-        pg_cmd += ' -U %(db_user)s' % self.db_details
+        pg_cmd += ' -U {db_user!s}'.format(**self.db_details)
         if self.db_details.get('db_pass') not in (None, ''):
-            pg_cmd = 'export PGPASSWORD=%(db_pass)s && ' % self.db_details + pg_cmd
+            pg_cmd = 'export PGPASSWORD={db_pass!s} && '.format(**self.db_details) + pg_cmd
         if self.db_details.get('db_host') not in (None, ''):
-            pg_cmd += ' -h %(db_host)s' % self.db_details
+            pg_cmd += ' -h {db_host!s}'.format(**self.db_details)
         if self.db_details.get('db_port') not in (None, ''):
-            pg_cmd += ' -p %(db_port)s' % self.db_details
+            pg_cmd += ' -p {db_port!s}'.format(**self.db_details)
         return pg_cmd
 
     def _get_psql_cmd(self):
         psql_cmd = self._get_postgres_cmd('psql')
-        psql_cmd += ' -d %(db_name)s' % self.db_details
+        psql_cmd += ' -d {db_name!s}'.format(**self.db_details)
         return psql_cmd
 
     def _postgres_dump(self, filepath):
         pg_dump_cmd = self._get_postgres_cmd('pg_dump')
-        pg_dump_cmd += ' %(db_name)s' % self.db_details
-        pg_dump_cmd += ' > %s' % filepath
+        pg_dump_cmd += ' {db_name!s}'.format(**self.db_details)
+        pg_dump_cmd += ' > {0!s}'.format(filepath)
         self._run_cmd(pg_dump_cmd)
-        print 'Dumped database to: %s' % filepath
+        print 'Dumped database to: {0!s}'.format(filepath)
 
     def _postgres_load(self, filepath):
         import ckan.model as model
         assert not model.repo.are_tables_created(), "Tables already found. You need to 'db clean' before a load."
-        pg_cmd = self._get_psql_cmd() + ' -f %s' % filepath
+        pg_cmd = self._get_psql_cmd() + ' -f {0!s}'.format(filepath)
         self._run_cmd(pg_cmd)
-        print 'Loaded CKAN database: %s' % filepath
+        print 'Loaded CKAN database: {0!s}'.format(filepath)
 
     def _run_cmd(self, command_line):
         import subprocess
         retcode = subprocess.call(command_line, shell=True)
         if retcode != 0:
-            raise SystemError('Command exited with errorcode: %i' % retcode)
+            raise SystemError('Command exited with errorcode: {0:d}'.format(retcode))
 
     def dump(self):
         if len(self.args) < 2:
@@ -362,7 +362,7 @@ class ManageDb(CkanCommand):
         import ckan.lib.rdf as rdf
         pkg = model.Package.by_name(unicode(package_name))
         if not pkg:
-            print 'Dataset name "%s" does not exist' % package_name
+            print 'Dataset name "{0!s}" does not exist'.format(package_name)
             return
         rdf = rdf.RdfExporter().export_package(pkg)
         f = open(rdf_path, 'w')
@@ -400,7 +400,7 @@ class ManageDb(CkanCommand):
         for id, revision_id, url  in results:
             response = requests.get(url, stream=True)
             if response.status_code != 200:
-                print "failed to fetch %s (code %s)" % (url,
+                print "failed to fetch {0!s} (code {1!s})".format(url,
                                                         response.status_code)
                 continue
             resource_upload = ResourceUpload({'id': id})
@@ -426,7 +426,7 @@ class ManageDb(CkanCommand):
                             "where id = '%s' and "
                             "revision_id = '%s'" % (id, revision_id))
             Session.commit()
-            print "Saved url %s" % url
+            print "Saved url {0!s}".format(url)
 
     def version(self):
         from ckan.model import Session
@@ -495,7 +495,7 @@ Default is false.'''
         elif cmd == 'clear':
             self.clear()
         else:
-            print 'Command %s not recognized' % cmd
+            print 'Command {0!s} not recognized'.format(cmd)
 
     def rebuild(self):
         from ckan.lib.search import rebuild, commit
@@ -602,7 +602,7 @@ class Notification(CkanCommand):
             for package in Session.query(Package):
                 dome.notify(package, DomainObjectOperation.changed)
         else:
-            print 'Command %s not recognized' % cmd
+            print 'Command {0!s} not recognized'.format(cmd)
 
 
 class RDFExport(CkanCommand):
@@ -691,15 +691,15 @@ class Sysadmin(CkanCommand):
         elif cmd == 'remove':
             self.remove()
         else:
-            print 'Command %s not recognized' % cmd
+            print 'Command {0!s} not recognized'.format(cmd)
 
     def list(self):
         import ckan.model as model
         print 'Sysadmins:'
         sysadmins = model.Session.query(model.User).filter_by(sysadmin=True)
-        print 'count = %i' % sysadmins.count()
+        print 'count = {0:d}'.format(sysadmins.count())
         for sysadmin in sysadmins:
-            print '%s name=%s id=%s' % (sysadmin.__class__.__name__,
+            print '{0!s} name={1!s} id={2!s}'.format(sysadmin.__class__.__name__,
                                         sysadmin.name,
                                         sysadmin.id)
 
@@ -713,11 +713,11 @@ class Sysadmin(CkanCommand):
 
         user = model.User.by_name(unicode(username))
         if not user:
-            print 'User "%s" not found' % username
-            makeuser = raw_input('Create new user: %s? [y/n]' % username)
+            print 'User "{0!s}" not found'.format(username)
+            makeuser = raw_input('Create new user: {0!s}? [y/n]'.format(username))
             if makeuser == 'y':
                 password = UserCmd.password_prompt()
-                print('Creating %s user' % username)
+                print('Creating {0!s} user'.format(username))
                 user = model.User(name=unicode(username),
                                   password=password)
             else:
@@ -727,7 +727,7 @@ class Sysadmin(CkanCommand):
         user.sysadmin = True
         model.Session.add(user)
         model.repo.commit_and_remove()
-        print 'Added %s as sysadmin' % username
+        print 'Added {0!s} as sysadmin'.format(username)
 
     def remove(self):
         import ckan.model as model
@@ -739,7 +739,7 @@ class Sysadmin(CkanCommand):
 
         user = model.User.by_name(unicode(username))
         if not user:
-            print 'Error: user "%s" not found!' % username
+            print 'Error: user "{0!s}" not found!'.format(username)
             return
         user.sysadmin = False
         model.repo.commit_and_remove()
@@ -789,16 +789,16 @@ class UserCmd(CkanCommand):
                 self.show()
 
     def get_user_str(self, user):
-        user_str = 'name=%s' % user.name
+        user_str = 'name={0!s}'.format(user.name)
         if user.name != user.display_name:
-            user_str += ' display=%s' % user.display_name
+            user_str += ' display={0!s}'.format(user.display_name)
         return user_str
 
     def list(self):
         import ckan.model as model
         print 'Users:'
         users = model.Session.query(model.User).filter_by(state = 'active')
-        print 'count = %i' % users.count()
+        print 'count = {0:d}'.format(users.count())
         for user in users:
             print self.get_user_str(user)
 
@@ -817,7 +817,7 @@ class UserCmd(CkanCommand):
             return
         username = self.args[1]
         user = model.User.get(username)
-        print('Editing user: %r' % user.name)
+        print('Editing user: {0!r}'.format(user.name))
 
         password = self.password_prompt()
         user.password = password
@@ -833,7 +833,7 @@ class UserCmd(CkanCommand):
         query_str = self.args[1]
 
         query = model.User.search(query_str)
-        print '%i users matching %r:' % (query.count(), query_str)
+        print '{0:d} users matching {1!r}:'.format(query.count(), query_str)
         for user in query.all():
             print self.get_user_str(user)
 
@@ -864,12 +864,12 @@ class UserCmd(CkanCommand):
                 field, value = arg.split('=', 1)
                 data_dict[field] = value
             except ValueError:
-                raise ValueError('Could not parse arg: %r (expected "<option>=<value>)"' % arg)
+                raise ValueError('Could not parse arg: {0!r} (expected "<option>=<value>)"'.format(arg))
 
         if 'password' not in data_dict:
             data_dict['password'] = self.password_prompt()
 
-        print('Creating user: %r' % username)
+        print('Creating user: {0!r}'.format(username))
 
         try:
             import ckan.logic as logic
@@ -896,11 +896,11 @@ class UserCmd(CkanCommand):
 
         user = model.User.by_name(unicode(username))
         if not user:
-            print 'Error: user "%s" not found!' % username
+            print 'Error: user "{0!s}" not found!'.format(username)
             return
         user.delete()
         model.repo.commit_and_remove()
-        print('Deleted user: %s' % username)
+        print('Deleted user: {0!s}'.format(username))
 
 
 class DatasetCmd(CkanCommand):
@@ -941,16 +941,16 @@ class DatasetCmd(CkanCommand):
         import ckan.model as model
         print 'Datasets:'
         datasets = model.Session.query(model.Package)
-        print 'count = %i' % datasets.count()
+        print 'count = {0:d}'.format(datasets.count())
         for dataset in datasets:
-            state = ('(%s)' % dataset.state) if dataset.state != 'active' \
+            state = ('({0!s})'.format(dataset.state)) if dataset.state != 'active' \
                     else ''
-            print '%s %s %s' % (dataset.id, dataset.name, state)
+            print '{0!s} {1!s} {2!s}'.format(dataset.id, dataset.name, state)
 
     def _get_dataset(self, dataset_ref):
         import ckan.model as model
         dataset = model.Package.get(unicode(dataset_ref))
-        assert dataset, 'Could not find dataset matching reference: %r' % dataset_ref
+        assert dataset, 'Could not find dataset matching reference: {0!r}'.format(dataset_ref)
         return dataset
 
     def show(self, dataset_ref):
@@ -967,7 +967,7 @@ class DatasetCmd(CkanCommand):
         dataset.delete()
         model.repo.commit_and_remove()
         dataset = self._get_dataset(dataset_ref)
-        print '%s %s -> %s' % (dataset.name, old_state, dataset.state)
+        print '{0!s} {1!s} -> {2!s}'.format(dataset.name, old_state, dataset.state)
 
     def purge(self, dataset_ref):
         import ckan.model as model
@@ -977,7 +977,7 @@ class DatasetCmd(CkanCommand):
         rev = model.repo.new_revision()
         dataset.purge()
         model.repo.commit_and_remove()
-        print '%s purged' % name
+        print '{0!s} purged'.format(name)
 
 
 class Celery(CkanCommand):
@@ -1007,7 +1007,7 @@ class Celery(CkanCommand):
             elif cmd == 'clean':
                 self.clean()
             else:
-                print 'Command %s not recognized' % cmd
+                print 'Command {0!s} not recognized'.format(cmd)
                 sys.exit(1)
 
     def run_(self):
@@ -1024,13 +1024,13 @@ class Celery(CkanCommand):
         from kombu.transport.sqlalchemy.models import Message
         q = model.Session.query(Message)
         q_visible = q.filter_by(visible=True)
-        print '%i messages (total)' % q.count()
-        print '%i visible messages' % q_visible.count()
+        print '{0:d} messages (total)'.format(q.count())
+        print '{0:d} visible messages'.format(q_visible.count())
         for message in q:
             if message.visible:
-                print '%i: Visible' % (message.id)
+                print '{0:d}: Visible'.format((message.id))
             else:
-                print '%i: Invisible Sent:%s' % (message.id, message.sent_at)
+                print '{0:d}: Invisible Sent:{1!s}'.format(message.id, message.sent_at)
 
     def clean(self):
         self._load_config()
@@ -1043,7 +1043,7 @@ class Celery(CkanCommand):
         query = model.Session.execute("delete from kombu_message")
         query = model.Session.execute("select * from kombu_message")
         tasks_afterwards = query.rowcount
-        print '%i of %i tasks deleted' % (tasks_initially - tasks_afterwards,
+        print '{0:d} of {1:d} tasks deleted'.format(tasks_initially - tasks_afterwards,
                                           tasks_initially)
         if tasks_afterwards:
             print 'ERROR: Failed to delete all tasks'
@@ -1077,22 +1077,22 @@ class Ratings(CkanCommand):
         elif cmd == 'clean-anonymous':
             self.clean(user_ratings=False)
         else:
-            print 'Command %s not recognized' % cmd
+            print 'Command {0!s} not recognized'.format(cmd)
 
     def count(self):
         import ckan.model as model
         q = model.Session.query(model.Rating)
-        print "%i ratings" % q.count()
+        print "{0:d} ratings".format(q.count())
         q = q.filter(model.Rating.user_id == None)
-        print "of which %i are anonymous ratings" % q.count()
+        print "of which {0:d} are anonymous ratings".format(q.count())
 
     def clean(self, user_ratings=True):
         import ckan.model as model
         q = model.Session.query(model.Rating)
-        print "%i ratings" % q.count()
+        print "{0:d} ratings".format(q.count())
         if not user_ratings:
             q = q.filter(model.Rating.user_id == None)
-            print "of which %i are anonymous ratings" % q.count()
+            print "of which {0:d} are anonymous ratings".format(q.count())
         ratings = q.all()
         for rating in ratings:
             rating.purge()
@@ -1161,7 +1161,7 @@ class Tracking(CkanCommand):
         while start_date < end_date:
             stop_date = start_date + datetime.timedelta(1)
             self.update_tracking(engine, start_date)
-            print 'tracking updated for %s' % start_date
+            print 'tracking updated for {0!s}'.format(start_date)
             start_date = stop_date
 
         self.update_tracking_solr(engine, start_date_solrsync)
@@ -1220,14 +1220,14 @@ class Tracking(CkanCommand):
         PACKAGE_URL = '/dataset/'
         # clear out existing data before adding new
         sql = '''DELETE FROM tracking_summary
-                 WHERE tracking_date='%s'; ''' % summary_date
+                 WHERE tracking_date='{0!s}'; '''.format(summary_date)
         engine.execute(sql)
 
         sql = '''SELECT DISTINCT url, user_key,
                      CAST(access_timestamp AS Date) AS tracking_date,
                      tracking_type INTO tracking_tmp
                  FROM tracking_raw
-                 WHERE CAST(access_timestamp as Date)='%s';
+                 WHERE CAST(access_timestamp as Date)='{0!s}';
 
                  INSERT INTO tracking_summary
                    (url, count, tracking_date, tracking_type)
@@ -1236,7 +1236,7 @@ class Tracking(CkanCommand):
                  GROUP BY url, tracking_date, tracking_type;
 
                  DROP TABLE tracking_tmp;
-                 COMMIT;''' % summary_date
+                 COMMIT;'''.format(summary_date)
         engine.execute(sql)
 
         # get ids for dataset urls
@@ -1297,21 +1297,21 @@ class Tracking(CkanCommand):
 
         total = len(package_ids)
         not_found = 0
-        print '%i package index%s to be rebuilt starting from %s' % (total, '' if total < 2 else 'es', start_date)
+        print '{0:d} package index{1!s} to be rebuilt starting from {2!s}'.format(total, '' if total < 2 else 'es', start_date)
 
         from ckan.lib.search import rebuild
         for package_id in package_ids:
             try:
                 rebuild(package_id)
             except logic.NotFound:
-                print "Error: package %s not found." % (package_id)
+                print "Error: package {0!s} not found.".format((package_id))
                 not_found += 1
             except KeyboardInterrupt:
                 print "Stopped."
                 return
             except:
                 raise
-        print 'search index rebuilding done.' + (' %i not found.' % (not_found) if not_found else "")
+        print 'search index rebuilding done.' + (' {0:d} not found.'.format((not_found)) if not_found else "")
 
 class PluginInfo(CkanCommand):
     '''Provide info on installed plugins.
@@ -1361,7 +1361,7 @@ class PluginInfo(CkanCommand):
                     extra = self.template_helpers(p['class'])
                 if i == 'IActions':
                     extra = self.actions(p['class'])
-                print '    %s' % i
+                print '    {0!s}'.format(i)
                 if extra:
                     print extra
             print
@@ -1398,12 +1398,12 @@ class PluginInfo(CkanCommand):
             if inspect.ismethod(fn) and inspect.isclass(fn.__self__):
                 params = params[1:]
             params = ', '.join(params)
-            output.append('        %s(%s)' % (function_name, params))
+            output.append('        {0!s}({1!s})'.format(function_name, params))
             # doc string
             if fn.__doc__:
                 bits = fn.__doc__.split('\n')
                 for bit in bits:
-                    output.append('            %s' % bit)
+                    output.append('            {0!s}'.format(bit))
         return ('\n').join(output)
 
 
@@ -1438,12 +1438,12 @@ class CreateTestDataCommand(CkanCommand):
         else:
             cmd = 'basic'
         if self.verbose:
-            print 'Creating %s test data' % cmd
+            print 'Creating {0!s} test data'.format(cmd)
         if cmd == 'basic':
             CreateTestData.create_basic_test_data()
         elif cmd == 'user':
             CreateTestData.create_test_user()
-            print 'Created user %r with password %r and apikey %r' % ('tester',
+            print 'Created user {0!r} with password {1!r} and apikey {2!r}'.format('tester',
                     'tester', 'tester')
         elif cmd == 'search':
             CreateTestData.create_search_test_data()
@@ -1458,10 +1458,10 @@ class CreateTestDataCommand(CkanCommand):
         elif cmd == 'hierarchy':
             CreateTestData.create_group_hierarchy_test_data()
         else:
-            print 'Command %s not recognized' % cmd
+            print 'Command {0!s} not recognized'.format(cmd)
             raise NotImplementedError
         if self.verbose:
-            print 'Creating %s test data: Complete!' % cmd
+            print 'Creating {0!s} test data: Complete!'.format(cmd)
 
 class Profile(CkanCommand):
     '''Code speed profiler
@@ -1493,7 +1493,7 @@ class Profile(CkanCommand):
             raise self.BadCommand(msg)
         self.filename = os.path.abspath(self.options.config)
         if not os.path.exists(self.filename):
-            raise AssertionError('Config filename %r does not exist.' % self.filename)
+            raise AssertionError('Config filename {0!r} does not exist.'.format(self.filename))
         fileConfig(self.filename)
 
         wsgiapp = loadapp('config:' + self.filename)
@@ -1520,10 +1520,10 @@ class Profile(CkanCommand):
                 traceback.print_exc()
                 print 'Unknown error: ', url.strip()
 
-        output_filename = 'ckan%s.profile' % re.sub('[/?]', '.', url.replace('/', '.'))
-        profile_command = "profile_url('%s')" % url
+        output_filename = 'ckan{0!s}.profile'.format(re.sub('[/?]', '.', url.replace('/', '.')))
+        profile_command = "profile_url('{0!s}')".format(url)
         cProfile.runctx(profile_command, globals(), locals(), filename=output_filename)
-        print 'Written profile to: %s' % output_filename
+        print 'Written profile to: {0!s}'.format(output_filename)
 
 
 class CreateColorSchemeCommand(CkanCommand):
@@ -1724,7 +1724,7 @@ class CreateColorSchemeCommand(CkanCommand):
             color = colorsys.hls_to_rgb(hue, _lightness, saturation)
             hex_color = '#'
             for part in color:
-                hex_color += '%02x' % int(part * 255)
+                hex_color += '{0:02x}'.format(int(part * 255))
             # check and remove any bad values
             if not re.match('^\#[0-9a-f]{6}$', hex_color):
                 hex_color='#FFFFFF'
@@ -1761,7 +1761,7 @@ class CreateColorSchemeCommand(CkanCommand):
                 try:
                     hue = float(self.args[0])
                 except ValueError:
-                    print 'ERROR argument `%s` not recognised' % arg
+                    print 'ERROR argument `{0!s}` not recognised'.format(arg)
             if rgb:
                 import colorsys
                 hue, lightness, saturation = colorsys.rgb_to_hls(*rgb)
@@ -1776,8 +1776,8 @@ class CreateColorSchemeCommand(CkanCommand):
             f = open(path, 'w')
             colors = self.create_colors(hue, saturation=saturation, lightness=lightness)
             for i in xrange(len(self.rules)):
-                f.write('%s: %s;\n' % (self.rules[i], colors[i]))
-                print '%s: %s;\n' % (self.rules[i], colors[i])
+                f.write('{0!s}: {1!s};\n'.format(self.rules[i], colors[i]))
+                print '{0!s}: {1!s};\n'.format(self.rules[i], colors[i])
             f.close
             print 'Color scheme has been created.'
         print 'Make sure less is run for changes to take effect.'
@@ -1882,7 +1882,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                               ensure_ascii=False, indent=2 * ' ')
             out_dir = os.path.abspath(os.path.join(self.ckan_path, 'public',
                                                    'base', 'i18n'))
-            out_file = open(os.path.join(out_dir, '%s.js' % lang), 'w')
+            out_file = open(os.path.join(out_dir, '{0!s}.js'.format(lang)), 'w')
             out_file.write(data.encode('utf-8'))
             out_file.close()
 
@@ -1997,7 +1997,7 @@ class MinifyCommand(CkanCommand):
             return
 
         if path_only.endswith('.min'):
-            print 'removing %s' % path
+            print 'removing {0!s}'.format(path)
             os.remove(path)
 
     def minify_file(self, path):
@@ -2109,12 +2109,12 @@ class LessCommand(CkanCommand):
 
 
     def compile_less(self, root, less_bin, color):
-        print 'compile %s.css' % color
+        print 'compile {0!s}.css'.format(color)
         import subprocess
         main_less = os.path.join(root, 'less', 'main.less')
-        main_css = os.path.join(root, 'css', '%s.css' % color)
+        main_css = os.path.join(root, 'css', '{0!s}.css'.format(color))
 
-        command = '%s %s %s' % (less_bin, main_less, main_css)
+        command = '{0!s} {1!s} {2!s}'.format(less_bin, main_less, main_css)
 
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output = process.communicate()
@@ -2524,7 +2524,7 @@ Not used when using the `-d` option.''')
 
         print 'This command will delete.\n'
         for row in results:
-            print '%s of type %s' % (row[1], row[0])
+            print '{0!s} of type {1!s}'.format(row[1], row[0])
 
         result = query_yes_no('Do you want to delete these resource views:', default='no')
 
@@ -2566,12 +2566,11 @@ class ConfigToolCommand(paste.script.command.Command):
     def command(self):
         import config_tool
         if len(self.args) < 1:
-            self.parser.error('Not enough arguments (got %i, need at least 1)'
-                              % len(self.args))
+            self.parser.error('Not enough arguments (got {0:d}, need at least 1)'.format(len(self.args)))
         config_filepath = self.args[0]
         if not os.path.exists(config_filepath):
-            self.parser.error('Config filename %r does not exist.' %
-                              config_filepath)
+            self.parser.error('Config filename {0!r} does not exist.'.format(
+                              config_filepath))
         if self.options.merge_filepath:
             config_tool.config_edit_using_merge_file(
                 config_filepath, self.options.merge_filepath)

--- a/ckan/lib/config_tool.py
+++ b/ckan/lib/config_tool.py
@@ -69,17 +69,17 @@ class Option(object):
         self.original = original
 
     def __repr__(self):
-        return '<Option [%s] %s>' % (self.section, self)
+        return '<Option [{0!s}] {1!s}>'.format(self.section, self)
 
     def __str__(self):
         if self.original:
             return self.original
-        return '%s%s = %s' % ('#' if self.is_commented_out else '',
+        return '{0!s}{1!s} = {2!s}'.format('#' if self.is_commented_out else '',
                               self.key, self.value)
 
     @property
     def id(self):
-        return '%s-%s' % (self.section, self.key)
+        return '{0!s}-{1!s}'.format(self.section, self.key)
 
     def comment_out(self):
         self.is_commented_out = True
@@ -120,8 +120,7 @@ def calculate_changes(existing_options_dict, desired_options, edit):
                  else 'add'
         if edit and action != 'edit':
             raise ConfigToolError(
-                'Key "%s" does not exist in section "%s"' %
-                (desired_option.key, desired_option.section))
+                'Key "{0!s}" does not exist in section "{1!s}"'.format(desired_option.key, desired_option.section))
         changes.add(action, desired_option)
     return changes
 
@@ -164,12 +163,11 @@ def make_changes(input_lines, new_sections, changes):
 
     def insert_new_sections(new_sections):
         for section in new_sections:
-            output.append('[%s]' % section)
+            output.append('[{0!s}]'.format(section))
             for option in changes.get(section, 'add'):
                 write_option(option)
             write_option('')
-            print 'Created option %s = "%s" (NEW section "%s")' % \
-                (option.key, option.value, section)
+            print 'Created option {0!s} = "{1!s}" (NEW section "{2!s}")'.format(option.key, option.value, section)
 
     for line in input_lines:
         # leave blank lines alone
@@ -203,16 +201,13 @@ def make_changes(input_lines, new_sections, changes):
             key = existing_option.key
             if existing_option.id in options_already_edited:
                 if not existing_option.is_commented_out:
-                    print 'Commented out repeat of %s (section "%s")' % \
-                        (key, section)
+                    print 'Commented out repeat of {0!s} (section "{1!s}")'.format(key, section)
                     existing_option.comment_out()
                 else:
-                    print 'Left commented out repeat of %s (section "%s")' % \
-                        (key, section)
+                    print 'Left commented out repeat of {0!s} (section "{1!s}")'.format(key, section)
             elif not existing_option.is_commented_out and \
                     updated_option.is_commented_out:
-                changes_made = 'Commented out %s (section "%s")' % \
-                    (key, section)
+                changes_made = 'Commented out {0!s} (section "{1!s}")'.format(key, section)
             elif existing_option.is_commented_out and \
                     not updated_option.is_commented_out:
                 changes_made = 'Option uncommented and set %s = "%s" ' \

--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -169,8 +169,8 @@ class CreateTestData(object):
                     if item.has_key(field):
                         pkg_dict[field] = unicode(item[field])
                 if model.Package.by_name(pkg_dict['name']):
-                    log.warning('Cannot create package "%s" as it already exists.' % \
-                                    (pkg_dict['name']))
+                    log.warning('Cannot create package "{0!s}" as it already exists.'.format( \
+                                    (pkg_dict['name'])))
                     continue
                 pkg = model.Package(**pkg_dict)
                 model.Session.add(pkg)
@@ -343,8 +343,8 @@ class CreateTestData(object):
                                 'type', 'is_organization'))
         for group_dict in group_dicts:
             if model.Group.by_name(unicode(group_dict['name'])):
-                log.warning('Cannot create group "%s" as it already exists.' %
-                            group_dict['name'])
+                log.warning('Cannot create group "{0!s}" as it already exists.'.format(
+                            group_dict['name']))
                 continue
             pkg_names = group_dict.pop('packages', [])
             group = model.Group(name=unicode(group_dict['name']))
@@ -550,8 +550,8 @@ left arrow <
         if model.User.by_name(name) or \
                 (user_dict.get('open_id') and
                  model.User.by_openid(user_dict.get('openid'))):
-            log.warning('Cannot create user "%s" as it already exists.' %
-                        name or user_dict['name'])
+            log.warning('Cannot create user "{0!s}" as it already exists.'.format(
+                        name) or user_dict['name'])
             return
         # User objects are not revisioned so no need to create a revision
         user_ref = name or user_dict['openid']

--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -97,7 +97,7 @@ def get_preview_plugin(data_dict, return_first=False):
     if num_plugins == 0:
         # we didn't find any.  see if any could be made to work
         for plug in plugins_fixable:
-            log.info('%s would allow previews.  To fix: %s' % (
+            log.info('{0!s} would allow previews.  To fix: {1!s}'.format(
                 plug['plugin'], plug['fixable']))
         preview_plugin = None
     elif num_plugins == 1:

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -474,7 +474,7 @@ def group_dictize(group, context,
         #of potential vulnerability of dodgy api input
         image_url = munge.munge_filename(image_url)
         result_dict['image_display_url'] = h.url_for_static(
-            'uploads/group/%s' % result_dict.get('image_url'),
+            'uploads/group/{0!s}'.format(result_dict.get('image_url')),
             qualified=True
         )
     return result_dict
@@ -659,7 +659,7 @@ def package_to_api(pkg, context):
 
     site_url = config.get('ckan.site_url', None)
     if site_url:
-        dictized['ckan_url'] = '%s/dataset/%s' % (site_url, pkg.name)
+        dictized['ckan_url'] = '{0!s}/dataset/{1!s}'.format(site_url, pkg.name)
 
     for resource in dictized["resources"]:
         resource_dict_to_api(resource, pkg.id, context)

--- a/ckan/lib/dumper.py
+++ b/ckan/lib/dumper.py
@@ -18,7 +18,7 @@ class SimpleDumper(object):
         elif format == 'json':
             self.dump_json(dump_file_obj, query)
         else:
-            raise Exception('Unknown format: %s' % format)
+            raise Exception('Unknown format: {0!s}'.format(format))
 
     def dump_csv(self, dump_file_obj, query):
         row_dicts = []
@@ -29,7 +29,7 @@ class SimpleDumper(object):
                 if isinstance(value, (list, tuple)):
                     if value and isinstance(value[0], dict) and name == 'resources':
                         for i, res in enumerate(value):
-                            prefix = 'resource-%i' % i
+                            prefix = 'resource-{0:d}'.format(i)
                             pkg_dict[prefix + '-url'] = res['url']
                             pkg_dict[prefix + '-format'] = res['format']
                             pkg_dict[prefix + '-description'] = res['description']
@@ -91,7 +91,7 @@ class Dumper(object):
                 dump_struct[model_class_name][record.id] = recorddict
         if verbose:
             print '---------------------------------'
-            print 'Dumping to %s' % dump_path
+            print 'Dumping to {0!s}'.format(dump_path)
         json.dump(dump_struct, file(dump_path, 'w'), indent=4, sort_keys=True)
 
     def cvt_record_to_dict(self, record, table):
@@ -113,7 +113,7 @@ class Dumper(object):
         ckan.model.metadata.create_all()
         for model_class in self.model_classes:
             if model.Session.query(model_class).count():
-                raise Exception, "Existing '%s' records in database" % model_class
+                raise Exception, "Existing '{0!s}' records in database".format(model_class)
 
         records = {}
         for model_class in self.model_classes:
@@ -165,12 +165,12 @@ class Dumper(object):
             if model_class == ckan.model.User: # ApiKey does not have idseq
                 continue
             table = self.get_table(model_class)
-            seqname = '%s_id_seq' % table.name 
+            seqname = '{0!s}_id_seq'.format(table.name) 
             q = table.select()
             print model_class
             maxid = q.order_by(table.c.id.desc()).execute().fetchone().id
             print seqname, maxid+1
-            sql = "SELECT setval('%s', %s);" % (seqname, maxid+1)
+            sql = "SELECT setval('{0!s}', {1!s});".format(seqname, maxid+1)
             engine = ckan.model.metadata.bind
             engine.execute(sql)
 
@@ -288,11 +288,11 @@ class PackagesXlWriter:
                 del dict_[key]
             if key=='resources':
                 for i, res in enumerate(value):
-                    prefix = 'resource-%i' % i
+                    prefix = 'resource-{0:d}'.format(i)
                     keys = model.Resource.get_columns()
                     keys += [key_ for key_ in pkg.resources[i].extras.keys() if key_ not in keys]
                     for field in keys:
-                        dict_['%s-%s' % (prefix, field)] = res[field]
+                        dict_['{0!s}-{1!s}'.format(prefix, field)] = res[field]
                 del dict_[key]
             elif isinstance(value, (list, tuple)):
                 dict_[key] = ' '.join(value)

--- a/ckan/lib/fanstatic_extensions.py
+++ b/ckan/lib/fanstatic_extensions.py
@@ -12,7 +12,7 @@ class CkanCustomRenderer(object):
         end = ''
         # IE conditionals
         if condition:
-            start = '<!--[if %s]>' % condition
+            start = '<!--[if {0!s}]>'.format(condition)
             end = '<![endif]-->'
             if other_browsers:
                 start += '<!-->'
@@ -22,16 +22,16 @@ class CkanCustomRenderer(object):
 
     def __call__(self, url):
         if self.script:
-            return '%s<script>%s</script>%s' % (self.start,
+            return '{0!s}<script>{1!s}</script>{2!s}'.format(self.start,
                                self.script,
                                self.end)
-        return '%s%s%s' % (self.start,
+        return '{0!s}{1!s}{2!s}'.format(self.start,
                            self.renderer(url),
                            self.end)
 
 
 def render_js(url):
-    return '<script src="%s"></script>' % (url,)
+    return '<script src="{0!s}"></script>'.format(url)
 
 #    __  __             _                ____       _       _
 #   |  \/  | ___  _ __ | | _____ _   _  |  _ \ __ _| |_ ___| |__
@@ -53,7 +53,7 @@ def render(self, library_url):
     # relpath = ''.join([self.dirname, BUNDLE_PREFIX, ';'.join(paths)])
     relpath = ''.join([core.BUNDLE_PREFIX, ';'.join(paths)])
 
-    return self.renderer('%s/%s' % (library_url, relpath))
+    return self.renderer('{0!s}/{1!s}'.format(library_url, relpath))
 
 core.Bundle.render = render
 

--- a/ckan/lib/fanstatic_resources.py
+++ b/ckan/lib/fanstatic_resources.py
@@ -30,9 +30,9 @@ def create_library(name, path, depend_base=True):
         ''' Attempt to get the resource from the current lib or if not try
         assume it is a fully qualified resource name. '''
         try:
-            res = getattr(module, '%s/%s' % (lib_name, resource_name))
+            res = getattr(module, '{0!s}/{1!s}'.format(lib_name, resource_name))
         except AttributeError:
-            res = getattr(module, '%s' % resource_name)
+            res = getattr(module, '{0!s}'.format(resource_name))
         return res
 
     def create_resource(path, lib_name, count, inline=False):
@@ -96,7 +96,7 @@ def create_library(name, path, depend_base=True):
                 setattr(min_res, attribute, getattr(resource, attribute))
 
         # add the resource to this module
-        fanstatic_name = '%s/%s' % (lib_name, path)
+        fanstatic_name = '{0!s}/{1!s}'.format(lib_name, path)
         setattr(module, fanstatic_name, resource)
         return resource
 
@@ -209,10 +209,10 @@ def create_library(name, path, depend_base=True):
     for group_name in groups:
         members = []
         for member in groups[group_name]:
-            fanstatic_name = '%s/%s' % (name, member)
+            fanstatic_name = '{0!s}/{1!s}'.format(name, member)
             members.append(getattr(module, fanstatic_name))
         group = Group(members)
-        fanstatic_name = '%s/%s' % (name, group_name)
+        fanstatic_name = '{0!s}/{1!s}'.format(name, group_name)
         setattr(module, fanstatic_name, group)
 
     # finally add the library to this module

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -138,7 +138,7 @@ def url_for(*args, **kw):
         if not ver:
             raise Exception('api calls must specify the version! e.g. ver=3')
         # fix ver to include the slash
-        kw['ver'] = '/%s' % ver
+        kw['ver'] = '/{0!s}'.format(ver)
     my_url = _routes_default_url_for(*args, **kw)
     kw['__ckan_no_root'] = no_root
     return _add_i18n_to_url(my_url, locale=locale, **kw)
@@ -238,7 +238,7 @@ def _add_i18n_to_url(url_to_amend, **kw):
         if root[-1] == '/':
             root = root[:-1]
         url = url_to_amend[len(re.sub('/{{LANG}}', '', root_path)):]
-        url = '%s%s' % (root, url)
+        url = '{0!s}{1!s}'.format(root, url)
         root = re.sub('/{{LANG}}', '', root_path)
     else:
         if default_locale:
@@ -247,16 +247,16 @@ def _add_i18n_to_url(url_to_amend, **kw):
             # we need to strip the root from the url and the add it before
             # the language specification.
             url = url_to_amend[len(root):]
-            url = '%s/%s%s' % (root, locale, url)
+            url = '{0!s}/{1!s}{2!s}'.format(root, locale, url)
 
     # stop the root being added twice in redirects
     if no_root:
         url = url_to_amend[len(root):]
         if not default_locale:
-            url = '/%s%s' % (locale, url)
+            url = '/{0!s}{1!s}'.format(locale, url)
 
     if url == '/packages':
-        error = 'There is a broken url being created %s' % kw
+        error = 'There is a broken url being created {0!s}'.format(kw)
         raise ckan.exceptions.CkanUrlException(error)
 
     return url
@@ -338,15 +338,14 @@ class _Flash(object):
         if default_category is not None:
             self.default_category = default_category
         if self.categories and self.default_category not in self.categories:
-            raise ValueError("unrecognized default category %r"
-                             % (self.default_category, ))
+            raise ValueError("unrecognized default category {0!r}".format(self.default_category ))
 
     def __call__(self, message, category=None, ignore_duplicate=False,
                  allow_html=False):
         if not category:
             category = self.default_category
         elif self.categories and category not in self.categories:
-            raise ValueError("unrecognized category %r" % (category, ))
+            raise ValueError("unrecognized category {0!r}".format(category ))
         # Don't store Message objects in the session, to avoid unpickling
         # errors in edge cases.
         new_message_tuple = (category, message, allow_html)
@@ -426,7 +425,7 @@ def _link_to(text, *args, **kwargs):
         if kwargs.pop('inner_span', None):
             text = literal('<span>') + text + literal('</span>')
         if icon:
-            text = literal('<i class="icon-%s"></i> ' % icon) + text
+            text = literal('<i class="icon-{0!s}"></i> '.format(icon)) + text
         return text
 
     icon = kwargs.pop('icon', None)
@@ -560,15 +559,14 @@ def _make_menu_item(menu_item, title, **kw):
     '''
     _menu_items = config['routes.named_routes']
     if menu_item not in _menu_items:
-        raise Exception('menu item `%s` cannot be found' % menu_item)
+        raise Exception('menu item `{0!s}` cannot be found'.format(menu_item))
     item = copy.copy(_menu_items[menu_item])
     item.update(kw)
     active = _link_active(item)
     needed = item.pop('needed')
     for need in needed:
         if need not in kw:
-            raise Exception('menu item `%s` need parameter `%s`'
-                            % (menu_item, need))
+            raise Exception('menu item `{0!s}` need parameter `{1!s}`'.format(menu_item, need))
     link = _link_to(title, menu_item, suppress_active_class=True, **item)
     if active:
         return literal('<li class="active">') + link + literal('</li>')
@@ -674,7 +672,7 @@ def unselected_facet_items(facet, limit=10):
 def get_facet_title(name):
     '''Deprecated in ckan 2.0 '''
     # if this is set in the config use this
-    config_title = config.get('search.facets.%s.title' % name)
+    config_title = config.get('search.facets.{0!s}.title'.format(name))
     if config_title:
         return config_title
 
@@ -802,7 +800,7 @@ def markdown_extract(text, extract_length=190):
 
 
 def icon_url(name):
-    return url_for_static('/images/icons/%s.png' % name)
+    return url_for_static('/images/icons/{0!s}.png'.format(name))
 
 
 def icon_html(url, alt=None, inline=True):
@@ -855,8 +853,8 @@ def dict_list_reduce(list_, key, unique=True):
 def linked_gravatar(email_hash, size=100, default=None):
     return literal(
         '<a href="https://gravatar.com/" target="_blank" ' +
-        'title="%s" alt="">' % _('Update your avatar at gravatar.com') +
-        '%s</a>' % gravatar(email_hash, size, default)
+        'title="{0!s}" alt="">'.format(_('Update your avatar at gravatar.com')) +
+        '{0!s}</a>'.format(gravatar(email_hash, size, default))
     )
 
 _VALID_GRAVATAR_DEFAULTS = ['404', 'mm', 'identicon', 'monsterid',
@@ -871,9 +869,8 @@ def gravatar(email_hash, size=100, default=None):
         # treat the default as a url
         default = urllib.quote(default, safe='')
 
-    return literal('''<img src="//gravatar.com/avatar/%s?s=%d&amp;d=%s"
-        class="gravatar" width="%s" height="%s" />'''
-                   % (email_hash, size, default, size, size)
+    return literal('''<img src="//gravatar.com/avatar/{0!s}?s={1:d}&amp;d={2!s}"
+        class="gravatar" width="{3!s}" height="{4!s}" />'''.format(email_hash, size, default, size, size)
                    )
 
 
@@ -918,7 +915,7 @@ class Page(paginate.Page):
         html = re.sub(dotdot, dotdot_link, html)
 
         # Convert current page
-        text = '%s' % self.page
+        text = '{0!s}'.format(self.page)
         current_page_span = str(HTML.span(c=text, **self.curpage_attr))
         current_page_link = self._pagerlink(self.page, text,
                                             extra_attributes=self.curpage_attr)
@@ -973,8 +970,8 @@ def date_str_to_datetime(date_str):
         m = re.match('(?P<seconds>\d{2})(\.(?P<microseconds>\d{6}))?$',
                      time_tuple[5])
         if not m:
-            raise ValueError('Unable to parse %s as seconds.microseconds' %
-                             time_tuple[5])
+            raise ValueError('Unable to parse {0!s} as seconds.microseconds'.format(
+                             time_tuple[5]))
         seconds = int(m.groupdict().get('seconds'))
         microseconds = int(m.groupdict(0).get('microseconds'))
         time_tuple = time_tuple[:5] + [seconds, microseconds]
@@ -1078,7 +1075,7 @@ def time_ago_from_timestamp(timestamp):
 
 def button_attr(enable, type='primary'):
     if enable:
-        return 'class="btn %s"' % type
+        return 'class="btn {0!s}"'.format(type)
     return 'disabled class="btn disabled"'
 
 
@@ -1170,16 +1167,16 @@ def auto_log_message():
 
 
 def activity_div(template, activity, actor, object=None, target=None):
-    actor = '<span class="actor">%s</span>' % actor
+    actor = '<span class="actor">{0!s}</span>'.format(actor)
     if object:
-        object = '<span class="object">%s</span>' % object
+        object = '<span class="object">{0!s}</span>'.format(object)
     if target:
-        target = '<span class="target">%s</span>' % target
+        target = '<span class="target">{0!s}</span>'.format(target)
     rendered_datetime = render_datetime(activity['timestamp'])
-    date = '<span class="date">%s</span>' % rendered_datetime
+    date = '<span class="date">{0!s}</span>'.format(rendered_datetime)
     template = template.format(actor=actor, date=date,
                                object=object, target=target)
-    template = '<div class="activity">%s %s</div>' % (template, date)
+    template = '<div class="activity">{0!s} {1!s}</div>'.format(template, date)
     return literal(template)
 
 
@@ -1247,7 +1244,7 @@ def follow_button(obj_type, obj_id):
     # If the user is logged in show the follow/unfollow button
     if c.user:
         context = {'model': model, 'session': model.Session, 'user': c.user}
-        action = 'am_following_%s' % obj_type
+        action = 'am_following_{0!s}'.format(obj_type)
         following = logic.get_action(action)(context, {'id': obj_id})
         return snippet('snippets/follow_button.html',
                        following=following,
@@ -1270,7 +1267,7 @@ def follow_count(obj_type, obj_id):
     '''
     obj_type = obj_type.lower()
     assert obj_type in _follow_objects
-    action = '%s_follower_count' % obj_type
+    action = '{0!s}_follower_count'.format(obj_type)
     context = {'model': model, 'session': model.Session, 'user': c.user}
     return logic.get_action(action)(context, {'id': obj_id})
 
@@ -1384,7 +1381,7 @@ def urls_for_resource(resource):
         else:
             relpath = resource.relpath
 
-        out.append('%s/%s' % (root_path, relpath))
+        out.append('{0!s}/{1!s}'.format(root_path, relpath))
     return out
 
 
@@ -1420,7 +1417,7 @@ def debug_full_info_as_list(debug_info):
             if not key in ignored_context_keys:
                 data = pprint.pformat(getattr(debug_vars['tmpl_context'], key))
                 data = data.decode('utf-8')
-                out.append(('c.%s' % key, data))
+                out.append(('c.{0!s}'.format(key), data))
 
     return out
 
@@ -1602,12 +1599,11 @@ def html_auto_link(data):
     def makelink(matchobj):
         obj = matchobj.group(1)
         name = matchobj.group(2)
-        title = '%s:%s' % (obj, name)
+        title = '{0!s}:{1!s}'.format(obj, name)
         return LINK_FNS[obj]({'name': name.strip('"'), 'title': title})
 
     def link(matchobj):
-        return '<a href="%s" target="_blank" rel="nofollow">%s</a>' \
-            % (matchobj.group(1), matchobj.group(1))
+        return '<a href="{0!s}" target="_blank" rel="nofollow">{1!s}</a>'.format(matchobj.group(1), matchobj.group(1))
 
     def process(matchobj):
         data = matchobj.group(2)
@@ -1954,7 +1950,7 @@ def resource_formats():
             try:
                 file_resource_formats = json.loads(format_file.read())
             except ValueError, e:  # includes simplejson.decoder.JSONDecodeError
-                raise ValueError('Invalid JSON syntax in %s: %s' % (format_file_path, e))
+                raise ValueError('Invalid JSON syntax in {0!s}: {1!s}'.format(format_file_path, e))
 
             for format_line in file_resource_formats:
                 if format_line[0] == '_comment':

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -41,7 +41,7 @@ def _get_locales():
     locales += [l for l in os.listdir(i18n_path) if localedata.exists(l)]
 
     assert locale_default in locales, \
-            'default language "%s" not available' % locale_default
+            'default language "{0!s}" not available'.format(locale_default)
 
     locale_list = []
     for locale in locales:

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -107,11 +107,9 @@ class CkanExtend(ext.Extension):
         if parser.stream.current.type != 'block_end':
             provided_template = parser.parse_expression().value
             if provided_template != filename:
-                raise Exception('ckan_extends tag wrong path %s in %s'
-                                % (provided_template, template_path))
+                raise Exception('ckan_extends tag wrong path {0!s} in {1!s}'.format(provided_template, template_path))
             else:
-                log.critical('Remove path from ckan_extend tag in %s'
-                             % template_path)
+                log.critical('Remove path from ckan_extend tag in {0!s}'.format(template_path))
 
         # provide our magic format
         # format is *<search path parent index>*<template name>
@@ -189,8 +187,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 contents = f.read().decode(self.encoding)
             except UnicodeDecodeError, e:
                 log.critical(
-                    'Template corruption in `%s` unicode decode errors'
-                    % filename
+                    'Template corruption in `{0!s}` unicode decode errors'.format(filename)
                 )
                 raise e
             finally:

--- a/ckan/lib/jsonp.py
+++ b/ckan/lib/jsonp.py
@@ -9,7 +9,7 @@ def to_jsonp(data):
     if 'callback' in request.params:
         response.headers['Content-Type'] = content_type
         cbname = request.params['callback']
-        result = '%s(%s);' % (cbname, result)
+        result = '{0!s}({1!s});'.format(cbname, result)
     else:
         response.headers['Content-Type'] = content_type
     return result

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -23,8 +23,8 @@ class MailerException(Exception):
 
 def add_msg_niceties(recipient_name, body, sender_name, sender_url):
     return _(u"Dear %s,") % recipient_name \
-           + u"\r\n\r\n%s\r\n\r\n" % body \
-           + u"--\r\n%s (%s)" % (sender_name, sender_url)
+           + u"\r\n\r\n{0!s}\r\n\r\n".format(body) \
+           + u"--\r\n{0!s} ({1!s})".format(sender_name, sender_url)
 
 def _mail_recipient(recipient_name, recipient_email,
         sender_name, sender_url, subject,
@@ -36,10 +36,10 @@ def _mail_recipient(recipient_name, recipient_email,
     subject = Header(subject.encode('utf-8'), 'utf-8')
     msg['Subject'] = subject
     msg['From'] = _("%s <%s>") % (sender_name, mail_from)
-    recipient = u"%s <%s>" % (recipient_name, recipient_email)
+    recipient = u"{0!s} <{1!s}>".format(recipient_name, recipient_email)
     msg['To'] = Header(recipient, 'utf-8')
     msg['Date'] = Utils.formatdate(time())
-    msg['X-Mailer'] = "CKAN %s" % ckan.__version__
+    msg['X-Mailer'] = "CKAN {0!s}".format(ckan.__version__)
 
     # Send the email using Python's smtplib.
     smtp_connection = smtplib.SMTP()
@@ -83,7 +83,7 @@ def _mail_recipient(recipient_name, recipient_email,
         log.info("Sent email to {0}".format(recipient_email))
 
     except smtplib.SMTPException, e:
-        msg = '%r' % e
+        msg = '{0!r}'.format(e)
         log.exception(msg)
         raise MailerException(msg)
     finally:

--- a/ckan/lib/maintain.py
+++ b/ckan/lib/maintain.py
@@ -106,11 +106,11 @@ def timer(params):
     if hasattr(params, '__call__'):
         # this is being used as a simple decorator
         fn = params
-        fn_name = '%s.%s' % (fn.__module__, fn.__name__)
+        fn_name = '{0!s}.{1!s}'.format(fn.__module__, fn.__name__)
         def wrapped(*args, **kw):
             start = time.time()
             result = fn(*args, **kw)
-            log.info('Timer: %s %.4f' % (fn_name, time.time() - start))
+            log.info('Timer: {0!s} {1:.4f}'.format(fn_name, time.time() - start))
             return result
         return wrapped
 
@@ -127,7 +127,7 @@ def timer(params):
             else:
                 # it could be passed in keywords
                 params_data.append((param))
-        fn_name = '%s.%s' % (fn.__module__, fn.__name__)
+        fn_name = '{0!s}.{1!s}'.format(fn.__module__, fn.__name__)
         def wrapped(*args, **kw):
             # store parameters being used in the call that we want to record
             params = []
@@ -139,12 +139,12 @@ def timer(params):
                     value = args[param[1]]
                 else:
                     continue
-                params.append(u'%s=%r' % (param[0], value))
+                params.append(u'{0!s}={1!r}'.format(param[0], value))
             p = ', '.join(params)
             start = time.time()
             # call the function
             result = fn(*args, **kw)
-            log.info('Timer: %s %.4f %s' % (fn_name, time.time() - start, p))
+            log.info('Timer: {0!s} {1:.4f} {2!s}'.format(fn_name, time.time() - start, p))
             return result
         return wrapped
     return decorator

--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -44,7 +44,7 @@ def munge_title_to_name(name):
         year_match = re.match('.*?[_-]((?:\d{2,4}[-/])?\d{2,4})$', name)
         if year_match:
             year = year_match.groups()[0]
-            name = '%s-%s' % (name[:(max_length-len(year)-1)], year)
+            name = '{0!s}-{1!s}'.format(name[:(max_length-len(year)-1)], year)
         else:
             name = name[:max_length]
     name = _munge_to_length(name, model.PACKAGE_NAME_MIN_LENGTH,

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -86,17 +86,17 @@ def register_package_plugins(map):
             # Create a connection between the newly named type and the
             # package controller
 
-            map.connect('%s_search' % package_type, '/%s' % package_type,
+            map.connect('{0!s}_search'.format(package_type), '/{0!s}'.format(package_type),
                         controller='package', action='search')
 
-            map.connect('%s_new' % package_type, '/%s/new' % package_type,
+            map.connect('{0!s}_new'.format(package_type), '/{0!s}/new'.format(package_type),
                         controller='package', action='new')
-            map.connect('%s_read' % package_type, '/%s/{id}' % package_type,
+            map.connect('{0!s}_read'.format(package_type), '/{0!s}/{{id}}'.format(package_type),
                         controller='package', action='read')
 
             for action in ['edit', 'authz', 'history']:
-                map.connect('%s_%s' % (package_type, action),
-                            '/%s/%s/{id}' % (package_type, action),
+                map.connect('{0!s}_{1!s}'.format(package_type, action),
+                            '/{0!s}/{1!s}/{{id}}'.format(package_type, action),
                             controller='package',
                             action=action)
 
@@ -154,14 +154,14 @@ def register_group_plugins(map):
             # to happen but it is executed sequentially from inside the
             # routing setup
 
-            map.connect('%s_index' % group_type, '/%s' % group_type,
+            map.connect('{0!s}_index'.format(group_type), '/{0!s}'.format(group_type),
                         controller=group_controller, action='index')
-            map.connect('%s_new' % group_type, '/%s/new' % group_type,
+            map.connect('{0!s}_new'.format(group_type), '/{0!s}/new'.format(group_type),
                         controller=group_controller, action='new')
-            map.connect('%s_read' % group_type, '/%s/{id}' % group_type,
+            map.connect('{0!s}_read'.format(group_type), '/{0!s}/{{id}}'.format(group_type),
                         controller=group_controller, action='read')
-            map.connect('%s_action' % group_type,
-                        '/%s/{action}/{id}' % group_type, controller=group_controller,
+            map.connect('{0!s}_action'.format(group_type),
+                        '/{0!s}/{{action}}/{{id}}'.format(group_type), controller=group_controller,
                         requirements=dict(action='|'.join(['edit', 'authz', 'history'])))
 
             if group_type in _group_plugins:

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -51,7 +51,7 @@ def template_info(template_name):
 
     template_path = find_template(template_name)
     if not template_path:
-        raise TemplateNotFound('Template %s cannot be found' % template_name)
+        raise TemplateNotFound('Template {0!s} cannot be found'.format(template_name))
     t_type = template_type(template_path)
 
     # if in debug mode we always want to search for templates so we

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -79,7 +79,7 @@ def index_for(_type):
         _type_n = _normalize_type(_type)
         return _INDICES[_type_n]()
     except KeyError, ke:
-        log.warn("Unknown search type: %s" % _type)
+        log.warn("Unknown search type: {0!s}".format(_type))
         return NoopSearchIndex()
 
 
@@ -90,7 +90,7 @@ def query_for(_type):
         _type_n = _normalize_type(_type)
         return _QUERIES[_type_n]()
     except KeyError, ke:
-        raise SearchError("Unknown search type: %s" % _type)
+        raise SearchError("Unknown search type: {0!s}".format(_type))
 
 
 def dispatch_by_operation(entity_type, entity, operation):
@@ -104,7 +104,7 @@ def dispatch_by_operation(entity_type, entity, operation):
         elif operation == model.domain_object.DomainObjectOperation.deleted:
             index.remove_dict(entity)
         else:
-            log.warn("Unknown operation: %s" % operation)
+            log.warn("Unknown operation: {0!s}".format(operation))
     except Exception, ex:
         log.exception(ex)
         # we really need to know about any exceptions, so reraise
@@ -132,7 +132,7 @@ class SynchronousSearchPlugin(p.SingletonPlugin):
             dispatch_by_operation(entity.__class__.__name__,
                                   {'id': entity.id}, operation)
         else:
-            log.warn("Discarded Sync. indexing for: %s" % entity)
+            log.warn("Discarded Sync. indexing for: {0!s}".format(entity))
 
 
 def rebuild(package_id=None, only_missing=False, force=False, refresh=False, defer_commit=False, package_ids=None):
@@ -192,8 +192,7 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False, def
                     defer_commit
                 )
             except Exception, e:
-                log.error('Error while indexing dataset %s: %s' %
-                          (pkg_id, str(e)))
+                log.error('Error while indexing dataset {0!s}: {1!s}'.format(pkg_id, str(e)))
                 if force:
                     log.error(text_traceback())
                     continue
@@ -218,7 +217,7 @@ def check():
     pkgs = set([pkg.id for pkg in pkgs_q])
     indexed_pkgs = set(package_query.get_all_entity_ids(max_results=len(pkgs)))
     pkgs_not_indexed = pkgs - indexed_pkgs
-    print 'Packages not indexed = %i out of %i' % (len(pkgs_not_indexed),
+    print 'Packages not indexed = {0:d} out of {1:d}'.format(len(pkgs_not_indexed),
                                                    len(pkgs))
     for pkg_id in pkgs_not_indexed:
         pkg = model.Session.query(model.Package).get(pkg_id)
@@ -234,8 +233,8 @@ def show(package_reference):
 def clear(package_reference=None):
     package_index = index_for(model.Package)
     if package_reference:
-        log.debug("Clearing search index for dataset %s..." %
-                  package_reference)
+        log.debug("Clearing search index for dataset {0!s}...".format(
+                  package_reference))
         package_index.delete_package({'id': package_reference})
     elif not SIMPLE_SEARCH:
         log.debug("Clearing search index...")
@@ -290,7 +289,7 @@ def check_solr_schema_version(schema_file=None):
 
         res = urllib2.urlopen(req)
     else:
-        url = 'file://%s' % schema_file
+        url = 'file://{0!s}'.format(schema_file)
         res = urllib2.urlopen(url)
 
     tree = xml.dom.minidom.parseString(res.read())

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -47,16 +47,16 @@ def escape_xml_illegal_chars(val, replacement=''):
 def clear_index():
     import solr.core
     conn = make_connection()
-    query = "+site_id:\"%s\"" % (config.get('ckan.site_id'))
+    query = "+site_id:\"{0!s}\"".format((config.get('ckan.site_id')))
     try:
         conn.delete_query(query)
         conn.commit()
     except socket.error, e:
-        err = 'Could not connect to SOLR %r: %r' % (conn.url, e)
+        err = 'Could not connect to SOLR {0!r}: {1!r}'.format(conn.url, e)
         log.error(err)
         raise SearchIndexError(err)
     except solr.core.SolrException, e:
-        err = 'SOLR %r exception: %r' % (conn.url, e)
+        err = 'SOLR {0!r} exception: {1!r}'.format(conn.url, e)
         log.error(err)
         raise SearchIndexError(err)
     finally:
@@ -79,11 +79,11 @@ class SearchIndex(object):
 
     def update_dict(self, data):
         """ Update data from a dictionary. """
-        log.debug("NOOP Index: %s" % ",".join(data.keys()))
+        log.debug("NOOP Index: {0!s}".format(",".join(data.keys())))
 
     def remove_dict(self, data):
         """ Delete an index entry uniquely identified by ``data``. """
-        log.debug("NOOP Delete: %s" % ",".join(data.keys()))
+        log.debug("NOOP Delete: {0!s}".format(",".join(data.keys())))
 
     def clear(self):
         """ Delete the complete index. """
@@ -153,7 +153,7 @@ class PackageSearchIndex(SearchIndex):
             if tag.get('vocabulary_id'):
                 data = {'id': tag['vocabulary_id']}
                 vocab = logic.get_action('vocabulary_show')(context, data)
-                key = u'vocab_%s' % vocab['name']
+                key = u'vocab_{0!s}'.format(vocab['name'])
                 if key in pkg_dict:
                     pkg_dict[key].append(tag['name'])
                 else:
@@ -267,7 +267,7 @@ class PackageSearchIndex(SearchIndex):
 
         # add a unique index_id to avoid conflicts
         import hashlib
-        pkg_dict['index_id'] = hashlib.md5('%s%s' % (pkg_dict['id'],config.get('ckan.site_id'))).hexdigest()
+        pkg_dict['index_id'] = hashlib.md5('{0!s}{1!s}'.format(pkg_dict['id'], config.get('ckan.site_id'))).hexdigest()
 
         for item in PluginImplementations(IPackageController):
             pkg_dict = item.before_index(pkg_dict)
@@ -294,7 +294,7 @@ class PackageSearchIndex(SearchIndex):
             conn.close()
 
         commit_debug_msg = 'Not commited yet' if defer_commit else 'Commited'
-        log.debug('Updated index for %s [%s]' % (pkg_dict.get('name'), commit_debug_msg))
+        log.debug('Updated index for {0!s} [{1!s}]'.format(pkg_dict.get('name'), commit_debug_msg))
 
     def commit(self):
         try:
@@ -309,7 +309,7 @@ class PackageSearchIndex(SearchIndex):
 
     def delete_package(self, pkg_dict):
         conn = make_connection()
-        query = "+%s:%s (+id:\"%s\" OR +name:\"%s\") +site_id:\"%s\"" % (TYPE_FIELD, PACKAGE_TYPE,
+        query = "+{0!s}:{1!s} (+id:\"{2!s}\" OR +name:\"{3!s}\") +site_id:\"{4!s}\"".format(TYPE_FIELD, PACKAGE_TYPE,
                                                        pkg_dict.get('id'), pkg_dict.get('id'),
                                                        config.get('ckan.site_id'))
         try:

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -56,21 +56,21 @@ def convert_legacy_parameters_to_solr(legacy_params):
         elif search_key == 'limit':
             solr_params['rows'] = value
         elif search_key == 'order_by':
-            solr_params['sort'] = '%s asc' % value
+            solr_params['sort'] = '{0!s} asc'.format(value)
         elif search_key == 'tags':
             if isinstance(value_obj, list):
                 tag_list = value_obj
             elif isinstance(value_obj, basestring):
                 tag_list = [value_obj]
             else:
-                raise SearchQueryError('Was expecting either a string or JSON list for the tags parameter: %r' % value)
-            solr_q_list.extend(['tags:"%s"' % escape_legacy_argument(tag) for tag in tag_list])
+                raise SearchQueryError('Was expecting either a string or JSON list for the tags parameter: {0!r}'.format(value))
+            solr_q_list.extend(['tags:"{0!s}"'.format(escape_legacy_argument(tag)) for tag in tag_list])
         else:
             if len(value.strip()):
                 value = escape_legacy_argument(value)
                 if ' ' in value:
-                    value = '"%s"' % value
-                solr_q_list.append('%s:%s' % (search_key, value))
+                    value = '"{0!s}"'.format(value)
+                solr_q_list.append('{0!s}:{1!s}'.format(search_key, value))
         del solr_params[search_key]
     solr_params['q'] = ' '.join(solr_q_list)
     if non_solr_params:
@@ -107,14 +107,14 @@ class QueryOptions(dict):
                 try:
                     value = asbool(value)
                 except ValueError:
-                    raise SearchQueryError('Value for search option %r must be True or False (1 or 0) but received %r' % (key, value))
+                    raise SearchQueryError('Value for search option {0!r} must be True or False (1 or 0) but received {1!r}'.format(key, value))
             elif key in self.INTEGER_OPTIONS:
                 try:
                     value = int(value)
                 except ValueError:
-                    raise SearchQueryError('Value for search option %r must be an integer but received %r' % (key, value))
+                    raise SearchQueryError('Value for search option {0!r} must be an integer but received {1!r}'.format(key, value))
             elif key in self.UNSUPPORTED_OPTIONS:
-                    raise SearchQueryError('Search option %r is not supported' % key)
+                    raise SearchQueryError('Search option {0!r} is not supported'.format(key))
             self[key] = value
 
     def __getattr__(self, name):
@@ -250,7 +250,7 @@ class PackageSearchQuery(SearchQuery):
         Return a list of the IDs of all indexed packages.
         """
         query = "*:*"
-        fq = "+site_id:\"%s\" " % config.get('ckan.site_id')
+        fq = "+site_id:\"{0!s}\" ".format(config.get('ckan.site_id'))
         fq += "+state:active "
 
         conn = make_connection()
@@ -264,22 +264,21 @@ class PackageSearchQuery(SearchQuery):
     def get_index(self,reference):
         query = {
             'rows': 1,
-            'q': 'name:"%s" OR id:"%s"' % (reference,reference),
+            'q': 'name:"{0!s}" OR id:"{1!s}"'.format(reference, reference),
             'wt': 'json',
-            'fq': 'site_id:"%s"' % config.get('ckan.site_id')}
+            'fq': 'site_id:"{0!s}"'.format(config.get('ckan.site_id'))}
 
         conn = make_connection()
-        log.debug('Package query: %r' % query)
+        log.debug('Package query: {0!r}'.format(query))
         try:
             solr_response = conn.raw_query(**query)
         except SolrException, e:
-            raise SearchError('SOLR returned an error running query: %r Error: %r' %
-                              (query, e.reason))
+            raise SearchError('SOLR returned an error running query: {0!r} Error: {1!r}'.format(query, e.reason))
         try:
             data = json.loads(solr_response)
 
             if data['response']['numFound'] == 0:
-                raise SearchError('Dataset not found in the search index: %s' % reference)
+                raise SearchError('Dataset not found in the search index: {0!s}'.format(reference))
             else:
                 return data['response']['docs'][0]
         except Exception, e:
@@ -303,7 +302,7 @@ class PackageSearchQuery(SearchQuery):
         # check that query keys are valid
         if not set(query.keys()) <= VALID_SOLR_PARAMETERS:
             invalid_params = [s for s in set(query.keys()) - VALID_SOLR_PARAMETERS]
-            raise SearchQueryError("Invalid search parameters: %s" % invalid_params)
+            raise SearchQueryError("Invalid search parameters: {0!s}".format(invalid_params))
 
         # default query is to return all documents
         q = query.get('q')
@@ -323,7 +322,7 @@ class PackageSearchQuery(SearchQuery):
         # show only results from this CKAN instance
         fq = query.get('fq', '')
         if not '+site_id:' in fq:
-            fq += ' +site_id:"%s"' % config.get('ckan.site_id')
+            fq += ' +site_id:"{0!s}"'.format(config.get('ckan.site_id'))
 
         # filter for package status
         if not '+state:' in fq:
@@ -356,12 +355,11 @@ class PackageSearchQuery(SearchQuery):
 
 
         conn = make_connection()
-        log.debug('Package query: %r' % query)
+        log.debug('Package query: {0!r}'.format(query))
         try:
             solr_response = conn.raw_query(**query)
         except SolrException, e:
-            raise SearchError('SOLR returned an error running query: %r Error: %r' %
-                              (query, e.reason))
+            raise SearchError('SOLR returned an error running query: {0!r} Error: {1!r}'.format(query, e.reason))
         try:
             data = json.loads(solr_response)
             response = data['response']

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -25,7 +25,7 @@ class AttributeDict(dict):
         try:
             return self[name]
         except KeyError:
-            raise AttributeError('No such attribute %r' % name)
+            raise AttributeError('No such attribute {0!r}'.format(name))
 
     def __setattr__(self, name, value):
         raise AttributeError(
@@ -352,7 +352,7 @@ def get_action(action):
 
     if _actions:
         if not action in _actions:
-            raise KeyError("Action '%s' not found" % action)
+            raise KeyError("Action '{0!s}' not found".format(action))
         return _actions.get(action)
     # Otherwise look in all the plugins to resolve all possible
     # First get the default ones in the ckan/logic/action directory
@@ -387,7 +387,7 @@ def get_action(action):
         for name, auth_function in plugin.get_actions().items():
             if name in resolved_action_plugins:
                 raise NameConflict(
-                    'The action %r is already implemented in %r' % (
+                    'The action {0!r} is already implemented in {1!r}'.format(
                         name,
                         resolved_action_plugins[name]
                     )
@@ -405,8 +405,7 @@ def get_action(action):
         def make_wrapped(_action, action_name):
             def wrapped(context=None, data_dict=None, **kw):
                 if kw:
-                    log.critical('%s was passed extra keywords %r'
-                                 % (_action.__name__, kw))
+                    log.critical('{0!s} was passed extra keywords {1!r}'.format(_action.__name__, kw))
 
                 context = _prepopulate_context(context)
 
@@ -426,7 +425,7 @@ def get_action(action):
                     audit = context['__auth_audit'][-1]
                     if audit[0] == action_name and audit[1] == id(_action):
                         if action_name not in new_authz.auth_functions_list():
-                            log.debug('No auth function for %s' % action_name)
+                            log.debug('No auth function for {0!s}'.format(action_name))
                         elif not getattr(_action, 'auth_audit_exempt', False):
                             raise Exception(
                                 'Action function {0} did not call its auth function'
@@ -641,14 +640,14 @@ def get_validator(validator):
             for name, fn in plugin.get_validators().items():
                 if name in _validators_cache:
                     raise NameConflict(
-                        'The validator %r is already defined' % (name,)
+                        'The validator {0!r} is already defined'.format(name)
                     )
                 log.debug('Validator function {0} from plugin {1} was inserted'.format(name, plugin.name))
                 _validators_cache[name] = fn
     try:
         return _validators_cache[validator]
     except KeyError:
-        raise UnknownValidator('Validator `%s` does not exist' % validator)
+        raise UnknownValidator('Validator `{0!s}` does not exist'.format(validator))
 
 
 def model_name_to_class(model_module, model_name):
@@ -660,7 +659,7 @@ def model_name_to_class(model_module, model_name):
         model_class_name = model_name.title()
         return getattr(model_module, model_class_name)
     except AttributeError:
-        raise ValidationError("%s isn't a valid model" % model_class_name)
+        raise ValidationError("{0!s} isn't a valid model".format(model_class_name))
 
 def _import_module_functions(module_path):
     '''Import a module and get the functions and return them in a dict'''

--- a/ckan/logic/action/__init__.py
+++ b/ckan/logic/action/__init__.py
@@ -41,7 +41,7 @@ def get_domain_object(model, domain_object_ref):
     user = model.User.get(domain_object_ref)
     if user:
         return user
-    raise NotFound('Domain object %r not found' % domain_object_ref)
+    raise NotFound('Domain object {0!r} not found'.format(domain_object_ref))
 
 
 def error_summary(error_dict):

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -218,7 +218,7 @@ def package_create(context, data_dict):
     context["package"] = pkg
     ## this is added so that the rest controller can make a new location
     context["id"] = pkg.id
-    log.debug('Created object %s' % pkg.name)
+    log.debug('Created object {0!s}'.format(pkg.name))
 
     # Make sure that a user provided schema is not used on package_show
     context.pop('schema', None)
@@ -541,7 +541,7 @@ def related_create(context, data_dict):
 
     context["related"] = related
     context["id"] = related.id
-    log.debug('Created object %s' % related.title)
+    log.debug('Created object {0!s}'.format(related.title))
     return related_dict
 
 
@@ -579,9 +579,9 @@ def package_relationship_create(context, data_dict):
     pkg1 = model.Package.get(id)
     pkg2 = model.Package.get(id2)
     if not pkg1:
-        raise NotFound('Subject package %r was not found.' % id)
+        raise NotFound('Subject package {0!r} was not found.'.format(id))
     if not pkg2:
-        return NotFound('Object package %r was not found.' % id2)
+        return NotFound('Object package {0!r} was not found.'.format(id2))
 
     data, errors = _validate(data_dict, schema, context)
     if errors:
@@ -651,7 +651,7 @@ def member_create(context, data_dict=None):
     obj_class = ckan.logic.model_name_to_class(model, obj_type)
     obj = obj_class.get(obj_id)
     if not obj:
-        raise NotFound('%s was not found.' % obj_type.title())
+        raise NotFound('{0!s} was not found.'.format(obj_type.title()))
 
     _check_access('member_create', context, data_dict)
 
@@ -784,7 +784,7 @@ def _group_or_org_create(context, data_dict, is_org=False):
     }
     logic.get_action('member_create')(member_create_context, member_dict)
 
-    log.debug('Created object %s' % group.name)
+    log.debug('Created object {0!s}'.format(group.name))
     return model_dictize.group_dictize(group, context)
 
 
@@ -954,7 +954,7 @@ def rating_create(context, data_dict):
                 opts_err = _('Rating must be between %i and %i.') \
                     % (model.MIN_RATING, model.MAX_RATING)
             elif not package:
-                opts_err = _('Not found') + ': %r' % package_ref
+                opts_err = _('Not found') + ': {0!r}'.format(package_ref)
     if opts_err:
         raise ValidationError(opts_err)
 
@@ -1100,7 +1100,7 @@ def _get_random_username_from_email(email):
 
     for i in range(max_name_creation_attempts):
         random_number = random.SystemRandom().random() * 10000
-        name = '%s-%d' % (cleaned_localpart, random_number)
+        name = '{0!s}-{1:d}'.format(cleaned_localpart, random_number)
         if not ckan.model.User.get(name):
             return name
 
@@ -1161,7 +1161,7 @@ def vocabulary_create(context, data_dict):
     if not context.get('defer_commit'):
         model.repo.commit()
 
-    log.debug('Created Vocabulary %s' % vocabulary.name)
+    log.debug('Created Vocabulary {0!s}'.format(vocabulary.name))
 
     return model_dictize.vocabulary_dictize(vocabulary, context)
 
@@ -1222,7 +1222,7 @@ def activity_create(context, activity_dict, **kw):
     if not context.get('defer_commit'):
         model.repo.commit()
 
-    log.debug("Created '%s' activity" % activity.activity_type)
+    log.debug("Created '{0!s}' activity".format(activity.activity_type))
     return model_dictize.activity_dictize(activity, context)
 
 
@@ -1278,7 +1278,7 @@ def tag_create(context, data_dict):
     if not context.get('defer_commit'):
         model.repo.commit()
 
-    log.debug("Created tag '%s' " % tag)
+    log.debug("Created tag '{0!s}' ".format(tag))
     return model_dictize.tag_dictize(tag, context)
 
 

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -178,16 +178,16 @@ def package_relationship_delete(context, data_dict):
     pkg1 = model.Package.get(id)
     pkg2 = model.Package.get(id2)
     if not pkg1:
-        raise NotFound('Subject package %r was not found.' % id)
+        raise NotFound('Subject package {0!r} was not found.'.format(id))
     if not pkg2:
-        return NotFound('Object package %r was not found.' % id2)
+        return NotFound('Object package {0!r} was not found.'.format(id2))
 
     existing_rels = pkg1.get_relationships_with(pkg2, rel)
     if not existing_rels:
         raise NotFound
 
     relationship = existing_rels[0]
-    revisioned_details = 'Package Relationship: %s %s %s' % (id, rel, id2)
+    revisioned_details = 'Package Relationship: {0!s} {1!s} {2!s}'.format(id, rel, id2)
 
     context['relationship'] = relationship
     _check_access('package_relationship_delete', context, data_dict)
@@ -271,7 +271,7 @@ def member_delete(context, data_dict=None):
     obj_class = ckan.logic.model_name_to_class(model, obj_type)
     obj = obj_class.get(obj_id)
     if not obj:
-        raise NotFound('%s was not found.' % obj_type.title())
+        raise NotFound('{0!s} was not found.'.format(obj_type.title()))
 
     _check_access('member_delete', context, data_dict)
 
@@ -305,7 +305,7 @@ def _group_or_org_delete(context, data_dict, is_org=False):
     if group is None:
         raise NotFound('Group was not found.')
 
-    revisioned_details = 'Group: %s' % group.name
+    revisioned_details = 'Group: {0!s}'.format(group.name)
 
     if is_org:
         _check_access('organization_delete', context, data_dict)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -883,8 +883,7 @@ def package_relationships_list(context, data_dict):
     relationships = pkg1.get_relationships(with_package=pkg2, type=rel)
 
     if rel and not relationships:
-        raise NotFound('Relationship "%s %s %s" not found.'
-                       % (id, rel, id2))
+        raise NotFound('Relationship "{0!s} {1!s} {2!s}" not found.'.format(id, rel, id2))
 
     relationship_dicts = [
         rel.as_dict(pkg1, ref_package_by=ref_package_by)
@@ -1439,7 +1438,7 @@ def package_autocomplete(context, data_dict):
     limit = data_dict.get('limit', 10)
     q = data_dict['q']
 
-    like_q = u"%s%%" % q
+    like_q = u"{0!s}%".format(q)
 
     query = model.Session.query(model.Package)
     query = query.filter(model.Package.state == 'active')
@@ -1456,7 +1455,7 @@ def package_autocomplete(context, data_dict):
             match_displayed = package.name
         else:
             match_field = 'title'
-            match_displayed = '%s (%s)' % (package.title, package.name)
+            match_displayed = '{0!s} ({1!s})'.format(package.title, package.name)
         result_dict = {
             'name': package.name,
             'title': package.title,
@@ -1714,8 +1713,7 @@ def package_search(context, data_dict):
             ## if the index has got a package that is not in ckan then
             ## ignore it.
             if not pkg:
-                log.warning('package %s in index but not in database'
-                            % package)
+                log.warning('package {0!s} in index but not in database'.format(package))
                 continue
             ## use data in search index if there
             if package_dict:
@@ -1942,9 +1940,9 @@ def resource_search(context, data_dict):
 
                 like = _or_(
                     model_attr.ilike(
-                        u'''%%"%s": "%%%s%%",%%''' % (field, term)),
+                        u'''%"{0!s}": "%{1!s}%",%'''.format(field, term)),
                     model_attr.ilike(
-                        u'''%%"%s": "%%%s%%"}''' % (field, term))
+                        u'''%"{0!s}": "%{1!s}%"}}'''.format(field, term))
                 )
                 q = q.filter(like)
 
@@ -3277,13 +3275,13 @@ def _unpick_search(sort, allowed_fields=None, total=None):
             order = 'asc'
         if allowed_fields:
             if field not in allowed_fields:
-                raise ValidationError('Cannot sort by field `%s`' % field)
+                raise ValidationError('Cannot sort by field `{0!s}`'.format(field))
         if order not in ['asc', 'desc']:
-            raise ValidationError('Invalid sort direction `%s`' % order)
+            raise ValidationError('Invalid sort direction `{0!s}`'.format(order))
         sorts.append((field, order))
     if total and len(sorts) > total:
         raise ValidationError(
-            'Too many sort criteria provided only %s allowed' % total)
+            'Too many sort criteria provided only {0!s} allowed'.format(total))
     return sorts
 
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -368,7 +368,7 @@ def package_update(context, data_dict):
     if not context.get('defer_commit'):
         model.repo.commit()
 
-    log.debug('Updated object %s' % pkg.name)
+    log.debug('Updated object {0!s}'.format(pkg.name))
 
     return_id_only = context.get('return_id_only', False)
 
@@ -475,9 +475,9 @@ def package_relationship_update(context, data_dict):
     pkg1 = model.Package.get(id)
     pkg2 = model.Package.get(id2)
     if not pkg1:
-        raise NotFound('Subject package %r was not found.' % id)
+        raise NotFound('Subject package {0!r} was not found.'.format(id))
     if not pkg2:
-        return NotFound('Object package %r was not found.' % id2)
+        return NotFound('Object package {0!r} was not found.'.format(id2))
 
     data, errors = _validate(data_dict, schema, context)
     if errors:
@@ -904,7 +904,7 @@ def term_translation_update_many(context, data_dict):
 
     model.Session.commit()
 
-    return {'success': '%s rows updated' % (num + 1)}
+    return {'success': '{0!s} rows updated'.format((num + 1))}
 
 
 ## Modifications for rest api
@@ -1051,13 +1051,13 @@ def user_role_update(context, data_dict):
         raise ValidationError('You must provide the "user" parameter.')
     domain_object_ref = _get_or_bust(data_dict, 'domain_object')
     if not isinstance(data_dict['roles'], (list, tuple)):
-        raise ValidationError('Parameter "%s" must be of type: "%s"' % ('role', 'list'))
+        raise ValidationError('Parameter "{0!s}" must be of type: "{1!s}"'.format('role', 'list'))
     desired_roles = set(data_dict['roles'])
 
     if new_user_ref:
         user_object = model.User.get(new_user_ref)
         if not user_object:
-            raise NotFound('Cannot find user %r' % new_user_ref)
+            raise NotFound('Cannot find user {0!r}'.format(new_user_ref))
         data_dict['user'] = user_object.id
         add_user_to_role_func = model.add_user_to_role
         remove_user_from_role_func = model.remove_user_from_role
@@ -1246,7 +1246,7 @@ def _bulk_update_dataset(context, data_dict, update_dict):
             'q': q,
             'fl': 'data_dict',
             'wt': 'json',
-            'fq': 'site_id:"%s"' % config.get('ckan.site_id'),
+            'fq': 'site_id:"{0!s}"'.format(config.get('ckan.site_id')),
             'rows': BATCH_SIZE
         }
 
@@ -1259,7 +1259,7 @@ def _bulk_update_dataset(context, data_dict, update_dict):
     count = 0
     q = []
     for id in datasets:
-        q.append('id:"%s"' % (id))
+        q.append('id:"{0!s}"'.format((id)))
         count += 1
         if count % BATCH_SIZE == 0:
             process_solr(' OR '.join(q))

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -116,7 +116,7 @@ def convert_user_name_or_id_to_id(user_name_or_id, context):
         result = session.query(model.User).filter_by(
                 name=user_name_or_id).first()
     if not result:
-        raise df.Invalid('%s: %s' % (_('Not found'), _('User')))
+        raise df.Invalid('{0!s}: {1!s}'.format(_('Not found'), _('User')))
     return result.id
 
 def convert_package_name_or_id_to_id(package_name_or_id, context):
@@ -141,7 +141,7 @@ def convert_package_name_or_id_to_id(package_name_or_id, context):
         result = session.query(model.Package).filter_by(
                 name=package_name_or_id).first()
     if not result:
-        raise df.Invalid('%s: %s' % (_('Not found'), _('Dataset')))
+        raise df.Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Dataset')))
     return result.id
 
 def convert_group_name_or_id_to_id(group_name_or_id, context):
@@ -166,7 +166,7 @@ def convert_group_name_or_id_to_id(group_name_or_id, context):
         result = session.query(model.Group).filter_by(
                 name=group_name_or_id).first()
     if not result:
-        raise df.Invalid('%s: %s' % (_('Not found'), _('Group')))
+        raise df.Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Group')))
     return result.id
 
 

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -134,7 +134,7 @@ def package_id_exists(value, context):
 
     result = session.query(model.Package).get(value)
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('Dataset')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Dataset')))
     return value
 
 def package_id_does_not_exist(value, context):
@@ -155,7 +155,7 @@ def package_name_exists(value, context):
     result = session.query(model.Package).filter_by(name=value).first()
 
     if not result:
-        raise Invalid(_('Not found') + ': %s' % value)
+        raise Invalid(_('Not found') + ': {0!s}'.format(value))
     return value
 
 def package_id_or_name_exists(package_id_or_name, context):
@@ -176,7 +176,7 @@ def package_id_or_name_exists(package_id_or_name, context):
             name=package_id_or_name).first()
 
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('Dataset')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Dataset')))
 
     return package_id_or_name
 
@@ -185,7 +185,7 @@ def resource_id_exists(value, context):
     model = context['model']
     session = context['session']
     if not session.query(model.Resource).get(value):
-        raise Invalid('%s: %s' % (_('Not found'), _('Resource')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Resource')))
     return value
 
 
@@ -199,7 +199,7 @@ def user_id_exists(user_id, context):
 
     result = session.query(model.User).get(user_id)
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('User')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('User')))
     return user_id
 
 def user_id_or_name_exists(user_id_or_name, context):
@@ -216,7 +216,7 @@ def user_id_or_name_exists(user_id_or_name, context):
         return user_id_or_name
     result = session.query(model.User).filter_by(name=user_id_or_name).first()
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('User')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('User')))
     return user_id_or_name
 
 def group_id_exists(group_id, context):
@@ -229,7 +229,7 @@ def group_id_exists(group_id, context):
 
     result = session.query(model.Group).get(group_id)
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('Group')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Group')))
     return group_id
 
 
@@ -243,7 +243,7 @@ def related_id_exists(related_id, context):
 
     result = session.query(model.Related).get(related_id)
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('Related')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Related')))
     return related_id
 
 def group_id_or_name_exists(reference, context):
@@ -267,7 +267,7 @@ def activity_type_exists(activity_type):
     if activity_type in object_id_validators:
         return activity_type
     else:
-        raise Invalid('%s: %s' % (_('Not found'), _('Activity type')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Activity type')))
 
 def resource_id_exists(value, context):
 
@@ -276,7 +276,7 @@ def resource_id_exists(value, context):
 
     result = session.query(model.Resource).get(value)
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('Resource')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('Resource')))
     return value
 
 # A dictionary mapping activity_type values from activity dicts to functions
@@ -447,7 +447,7 @@ def tag_not_uppercase(value, context):
 
     tagname_uppercase = re.compile('[A-Z]')
     if tagname_uppercase.search(value):
-        raise Invalid(_('Tag "%s" must not be uppercase' % (value)))
+        raise Invalid(_('Tag "{0!s}" must not be uppercase'.format((value))))
     return value
 
 def tag_string_convert(key, data, errors, context):
@@ -713,7 +713,7 @@ def user_name_exists(user_name, context):
     session = context['session']
     result = session.query(model.User).filter_by(name=user_name).first()
     if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('User')))
+        raise Invalid('{0!s}: {1!s}'.format(_('Not found'), _('User')))
     return result.name
 
 
@@ -757,7 +757,7 @@ def list_of_strings(key, data, errors, context):
         raise Invalid(_('Not a list'))
     for x in value:
         if not isinstance(x, basestring):
-            raise Invalid('%s: %s' % (_('Not a string'), x))
+            raise Invalid('{0!s}: {1!s}'.format(_('Not a string'), x))
 
 def if_empty_guess_format(key, data, errors, context):
     value = data[key]

--- a/ckan/migration/versions/008_update_vdm_ids.py
+++ b/ckan/migration/versions/008_update_vdm_ids.py
@@ -63,12 +63,12 @@ def upgrade2(migrate_engine, dropped_fk_constraints):
 
         # So we create via hand ...
         constraint_columns, foreign_key_cols, constraint_name, table_name = fk_constraint
-        oursql = '''ALTER TABLE %(table)s
-            ADD CONSTRAINT %(fkeyname)s
-            FOREIGN KEY (%(col_name)s)
+        oursql = '''ALTER TABLE {table!s}
+            ADD CONSTRAINT {fkeyname!s}
+            FOREIGN KEY ({col_name!s})
             REFERENCES revision (id)
-            ''' % {'table':table_name, 'fkeyname':constraint_name,
-                    'col_name':constraint_columns[0] }
+            '''.format(**{'table':table_name, 'fkeyname':constraint_name,
+                    'col_name':constraint_columns[0] })
         migrate_engine.execute(oursql)
 
     # 4 create uuids for revisions and in related tables

--- a/ckan/migration/versions/009_add_creation_timestamps.py
+++ b/ckan/migration/versions/009_add_creation_timestamps.py
@@ -13,7 +13,7 @@ def upgrade(migrate_engine):
     # Use sql instead of migrate.changeset because user and group are sql
     # reserved words and migrate doesn't quote them.
     for domain_obj_name in domain_obj_names:
-        sql = 'ALTER TABLE "%s" ADD created TIMESTAMP WITHOUT TIME ZONE' % domain_obj_name
+        sql = 'ALTER TABLE "{0!s}" ADD created TIMESTAMP WITHOUT TIME ZONE'.format(domain_obj_name)
         migrate_engine.execute(sql)
 
     now = datetime.now()

--- a/ckan/migration/versions/015_remove_state_object.py
+++ b/ckan/migration/versions/015_remove_state_object.py
@@ -22,7 +22,7 @@ def upgrade(migrate_engine):
         column = Column('state', UnicodeText)
         column.create(table)
         for (name,id) in [ ('active',1), ('deleted',2), ('pending',3) ]:
-            sqlcmd = '''UPDATE %s SET state = '%s' WHERE state_id = %s''' % (table.name, name, id)
+            sqlcmd = '''UPDATE {0!s} SET state = '{1!s}' WHERE state_id = {2!s}'''.format(table.name, name, id)
             migrate_engine.execute(sqlcmd)
         stateid = table.c['state_id']
         stateid.drop()

--- a/ckan/migration/versions/016_uuids_everywhere.py
+++ b/ckan/migration/versions/016_uuids_everywhere.py
@@ -132,13 +132,13 @@ def add_fk_constraints(migrate_engine, dropped_fk_constraints, primary_table_nam
 
         # So we create via hand ...
         constraint_columns, foreign_key_cols, constraint_name, table_name = fk_constraint
-        oursql = '''ALTER TABLE %(table)s
-            ADD CONSTRAINT %(fkeyname)s
-            FOREIGN KEY (%(col_name)s)
-            REFERENCES %(primary_table_name)s (id)
-            ''' % {'table':table_name, 'fkeyname':constraint_name,
+        oursql = '''ALTER TABLE {table!s}
+            ADD CONSTRAINT {fkeyname!s}
+            FOREIGN KEY ({col_name!s})
+            REFERENCES {primary_table_name!s} (id)
+            '''.format(**{'table':table_name, 'fkeyname':constraint_name,
                    'col_name':constraint_columns[0],
-                   'primary_table_name':primary_table_name}
+                   'primary_table_name':primary_table_name})
         migrate_engine.execute(oursql)
 
 def create_uuids(migrate_engine, primary_table_name, revision_table_name):
@@ -171,10 +171,10 @@ def drop_sequencies(migrate_engine):
 
 
     for sequence in sequencies:
-        migrate_engine.execute('ALTER TABLE %s ALTER COLUMN id DROP DEFAULT;' % sequence)
+        migrate_engine.execute('ALTER TABLE {0!s} ALTER COLUMN id DROP DEFAULT;'.format(sequence))
 
     for sequence in sequencies:
-        migrate_engine.execute('drop sequence %s_id_seq;' % sequence)
+        migrate_engine.execute('drop sequence {0!s}_id_seq;'.format(sequence))
 
 
             

--- a/ckan/migration/versions/018_adjust_licenses.py
+++ b/ckan/migration/versions/018_adjust_licenses.py
@@ -121,7 +121,7 @@ def downgrade(migrate_engine):
 def _check_map_has_old_license_titles(old_license_titles, map):
     for title in old_license_titles.values():
         if title not in map:
-            raise Exception, "The old license title '%s' wasn't found in the upgrade map. Decide which new license id should be substituted for this license and add an entry to the map (in ckan/migration/versions/018_adjust_licenses.py)." % title
+            raise Exception, "The old license title '{0!s}' wasn't found in the upgrade map. Decide which new license id should be substituted for this license and add an entry to the map (in ckan/migration/versions/018_adjust_licenses.py).".format(title)
 
 def _get_old_license_titles(migrate_engine):
     "Returns a dict of old license titles, keyed by old license id."
@@ -158,7 +158,7 @@ def _switch_package_license_ids(old_ids, old_license_titles, map):
             old_license_title = old_license_titles[old_license_id]
             new_license_id = map[old_license_title]
             new_ids[package_id] = new_license_id
-            print "Switched license_id %s to %s" % (old_license_id, new_license_id)
+            print "Switched license_id {0!s} to {1!s}".format(old_license_id, new_license_id)
     return new_ids
 
 def _set_new_package_license_ids(migrate_engine, new_ids):
@@ -166,7 +166,7 @@ def _set_new_package_license_ids(migrate_engine, new_ids):
         _set_package_license_id(migrate_engine, package_id, license_id)
 
 def _set_package_license_id(migrate_engine, package_id, license_id):
-    set_package_license_id = """UPDATE package SET license_id ='%s' where id = '%s';""" % (license_id, package_id)
+    set_package_license_id = """UPDATE package SET license_id ='{0!s}' where id = '{1!s}';""".format(license_id, package_id)
     migrate_engine.execute(set_package_license_id)
 
 def _set_new_package_revision_license_ids(migrate_engine, new_ids):
@@ -174,7 +174,7 @@ def _set_new_package_revision_license_ids(migrate_engine, new_ids):
         _set_package_revision_license_id(migrate_engine, package_id, license_id)
 
 def _set_package_revision_license_id(migrate_engine, package_id, license_id):
-    set_package_license_id = """UPDATE package_revision SET license_id ='%s' where id = '%s';""" % (license_id, package_id)
+    set_package_license_id = """UPDATE package_revision SET license_id ='{0!s}' where id = '{1!s}';""".format(license_id, package_id)
     migrate_engine.execute(set_package_license_id)
 
 

--- a/ckan/migration/versions/029_version_groups.py
+++ b/ckan/migration/versions/029_version_groups.py
@@ -116,7 +116,7 @@ def upgrade(migrate_engine):
     #q = group_table.update(values={'state': 'active',
     #                               'revision_id': rev_id})
     #migrate_engine.execute(q)
-    migrate_engine.execute('UPDATE "group" SET revision_id = \'%s\', state=\'active\'' % rev_id)
+    migrate_engine.execute('UPDATE "group" SET revision_id = \'{0!s}\', state=\'active\''.format(rev_id))
     #fk = ForeignKeyConstraint(['revision_id'], [revision_table.c.id], table=group_table)
     #fk.create(migrate_engine)
     migrate_engine.execute('ALTER TABLE "group" ADD CONSTRAINT "group_revision_id_fkey" ' + \

--- a/ckan/migration/versions/034_resource_group_table.py
+++ b/ckan/migration/versions/034_resource_group_table.py
@@ -114,10 +114,10 @@ ALTER TABLE resource
     migrate_engine.execute('''
 insert into resource_group 
     select 
-        %s, id, 'default', null, null, state, revision_id
+        {0!s}, id, 'default', null, null, state, revision_id
     from
         package;
-''' %  make_new_uuid("id")
+'''.format(make_new_uuid("id"))
 )
 
     migrate_engine.execute('''
@@ -130,11 +130,9 @@ insert into resource_group_revision
 )
 
     ## update resource table with new ids generated from the
-    migrate_engine.execute('update resource set resource_group_id = %s' 
-                           % make_new_uuid('resource_group_id'))
+    migrate_engine.execute('update resource set resource_group_id = {0!s}'.format(make_new_uuid('resource_group_id')))
 
-    migrate_engine.execute('update resource_revision set resource_group_id = %s' 
-                           % make_new_uuid('resource_group_id'))
+    migrate_engine.execute('update resource_revision set resource_group_id = {0!s}'.format(make_new_uuid('resource_group_id')))
 
 ##add back contraints
 

--- a/ckan/migration/versions/039_add_expired_id_and_dates.py
+++ b/ckan/migration/versions/039_add_expired_id_and_dates.py
@@ -10,25 +10,25 @@ def upgrade(migrate_engine):
 
 -- make sure all tables have an entry in the revision_table
 
-insert into revision values ('%(id)s' , '%(timestamp)s', 'admin', 'Admin: make sure every object has a row in a revision table', 'active');
+insert into revision values ('{id!s}' , '{timestamp!s}', 'admin', 'Admin: make sure every object has a row in a revision table', 'active');
 
-insert into package_tag_revision (id,package_id,tag_id,revision_id,state,continuity_id) select id,package_id,tag_id, '%(id)s' ,state, id from package_tag where package_tag.id not in (select id from package_tag_revision);
+insert into package_tag_revision (id,package_id,tag_id,revision_id,state,continuity_id) select id,package_id,tag_id, '{id!s}' ,state, id from package_tag where package_tag.id not in (select id from package_tag_revision);
 
-insert into resource_revision (id,resource_group_id,url,format,description,position,revision_id,hash,state,extras,continuity_id) select id,resource_group_id,url,format,description,position, '%(id)s' ,hash,state,extras, id from resource where resource.id not in (select id from resource_revision);
+insert into resource_revision (id,resource_group_id,url,format,description,position,revision_id,hash,state,extras,continuity_id) select id,resource_group_id,url,format,description,position, '{id!s}' ,hash,state,extras, id from resource where resource.id not in (select id from resource_revision);
 
-insert into group_extra_revision (id,group_id,key,value,state,revision_id,continuity_id) select id,group_id,key,value,state, '%(id)s' , id from group_extra where group_extra.id not in (select id from group_extra_revision);
+insert into group_extra_revision (id,group_id,key,value,state,revision_id,continuity_id) select id,group_id,key,value,state, '{id!s}' , id from group_extra where group_extra.id not in (select id from group_extra_revision);
 
-insert into resource_group_revision (id,package_id,label,sort_order,extras,state,revision_id,continuity_id) select id,package_id,label,sort_order,extras,state, '%(id)s', id from resource_group where resource_group.id not in (select id from resource_group_revision);
+insert into resource_group_revision (id,package_id,label,sort_order,extras,state,revision_id,continuity_id) select id,package_id,label,sort_order,extras,state, '{id!s}', id from resource_group where resource_group.id not in (select id from resource_group_revision);
 
-insert into package_extra_revision (id,package_id,key,value,revision_id,state,continuity_id) select id,package_id,key,value, '%(id)s',state, id from package_extra where package_extra.id not in (select id from package_extra_revision);
+insert into package_extra_revision (id,package_id,key,value,revision_id,state,continuity_id) select id,package_id,key,value, '{id!s}',state, id from package_extra where package_extra.id not in (select id from package_extra_revision);
 
-insert into package_relationship_revision (id,subject_package_id,object_package_id,type,comment,revision_id,state,continuity_id) select id,subject_package_id,object_package_id,type,comment, '%(id)s',state, id from package_relationship where package_relationship.id not in (select id from package_relationship_revision);
+insert into package_relationship_revision (id,subject_package_id,object_package_id,type,comment,revision_id,state,continuity_id) select id,subject_package_id,object_package_id,type,comment, '{id!s}',state, id from package_relationship where package_relationship.id not in (select id from package_relationship_revision);
                            
-insert into group_revision (id,name,title,description,created,state,revision_id,continuity_id) select id,name,title,description,created,state, '%(id)s', id from "group" where "group".id not in (select id from group_revision);
+insert into group_revision (id,name,title,description,created,state,revision_id,continuity_id) select id,name,title,description,created,state, '{id!s}', id from "group" where "group".id not in (select id from group_revision);
 
-insert into package_revision (id,name,title,url,notes,license_id,revision_id,version,author,author_email,maintainer,maintainer_email,state,continuity_id) select id,name,title,url,notes,license_id, '%(id)s',version,author,author_email,maintainer,maintainer_email,state, id from package where package.id not in (select id from package_revision);
+insert into package_revision (id,name,title,url,notes,license_id,revision_id,version,author,author_email,maintainer,maintainer_email,state,continuity_id) select id,name,title,url,notes,license_id, '{id!s}',version,author,author_email,maintainer,maintainer_email,state, id from package where package.id not in (select id from package_revision);
 
-''' % dict(id=id, timestamp=datetime.datetime.utcnow().isoformat())
+'''.format(**dict(id=id, timestamp=datetime.datetime.utcnow().isoformat()))
 
 
     update_schema = '''
@@ -208,10 +208,10 @@ update revision set approved_timestamp = timestamp;
     
     for table in ['package', 'resource', 'resource_group', 'package_extra', 
                   'package_tag', 'package_relationship', 'group', 'group_extra']:
-        count = migrate_engine.execute('''select count(*) from "%s"''' % table).first()[0]
-        revision_expired_id_count = migrate_engine.execute('''select count(*) from %s_revision where %s_revision.expired_id is null''' % (table, table)).first()[0]
-        revision_expired_data_count = migrate_engine.execute('''select count(*) from %s_revision where %s_revision.expired_timestamp = '9999-12-31' ''' % (table, table)).first()[0]
-        revision_current = migrate_engine.execute('''select count(*) from %s_revision where %s_revision.current = '1' ''' % (table, table)).first()[0]
+        count = migrate_engine.execute('''select count(*) from "{0!s}"'''.format(table)).first()[0]
+        revision_expired_id_count = migrate_engine.execute('''select count(*) from {0!s}_revision where {1!s}_revision.expired_id is null'''.format(table, table)).first()[0]
+        revision_expired_data_count = migrate_engine.execute('''select count(*) from {0!s}_revision where {1!s}_revision.expired_timestamp = '9999-12-31' '''.format(table, table)).first()[0]
+        revision_current = migrate_engine.execute('''select count(*) from {0!s}_revision where {1!s}_revision.current = '1' '''.format(table, table)).first()[0]
         assert count == revision_expired_id_count
         assert count == revision_expired_data_count
         assert count == revision_current

--- a/ckan/migration/versions/071_add_state_column_to_user_table.py
+++ b/ckan/migration/versions/071_add_state_column_to_user_table.py
@@ -4,6 +4,6 @@ import ckan.model
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''
-        ALTER TABLE "user" ADD COLUMN "state" text NOT NULL DEFAULT '%s'
-        ''' % ckan.model.State.ACTIVE
+        ALTER TABLE "user" ADD COLUMN "state" text NOT NULL DEFAULT '{0!s}'
+        '''.format(ckan.model.State.ACTIVE)
     )

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -304,7 +304,7 @@ class Repository(vdm.sqlalchemy.Repository):
         else:
             tables = reversed(self.metadata.sorted_tables)
         for table in tables:
-            connection.execute('delete from "%s"' % table.name)
+            connection.execute('delete from "{0!s}"'.format(table.name))
         self.session.commit()
         log.info('Database table data deleted')
 
@@ -324,8 +324,7 @@ class Repository(vdm.sqlalchemy.Repository):
         @param version: version to upgrade to (if None upgrade to latest)
         '''
         assert meta.engine.name in ('postgres', 'postgresql'), \
-            'Database migration - only Postgresql engine supported (not %s).' \
-                % meta.engine.name
+            'Database migration - only Postgresql engine supported (not {0!s}).'.format(meta.engine.name)
         import migrate.versioning.api as mig
         self.setup_migration_version_control()
         version_before = mig.db_version(self.metadata.bind, self.migrate_repository)
@@ -402,7 +401,7 @@ class Repository(vdm.sqlalchemy.Repository):
             for cont in to_purge:
                 self.session.delete(cont)
         if leave_record:
-            revision.message = u'PURGED: %s' % datetime.now()
+            revision.message = u'PURGED: {0!s}'.format(datetime.now())
         else:
             self.session.delete(revision)
         self.commit_and_remove()

--- a/ckan/model/authz.py
+++ b/ckan/model/authz.py
@@ -130,8 +130,7 @@ system_role_table = Table('system_role', meta.metadata,
 
 class RoleAction(domain_object.DomainObject):
     def __repr__(self):
-        return '<%s role="%s" action="%s" context="%s">' % \
-               (self.__class__.__name__, self.role, self.action, self.context)
+        return '<{0!s} role="{1!s}" action="{2!s}" context="{3!s}">'.format(self.__class__.__name__, self.role, self.action, self.context)
 
 
 # dictionary mapping protected objects (e.g. Package) to related ObjectRole
@@ -143,8 +142,7 @@ class UserObjectRole(domain_object.DomainObject):
 
     def __repr__(self):
         if self.user:
-            return '<%s user="%s" role="%s" context="%s">' % \
-                (self.__class__.__name__, self.user.name, self.role, self.context)
+            return '<{0!s} user="{1!s}" role="{2!s}" context="{3!s}">'.format(self.__class__.__name__, self.user.name, self.role, self.context)
         else:
             assert False, "UserObjectRole is not a user"
 
@@ -153,7 +151,7 @@ class UserObjectRole(domain_object.DomainObject):
         protected_object = protected_objects.get(domain_obj.__class__, None)
         if protected_object is None:
             # TODO: make into an authz exception
-            msg = '%s is not a protected object, i.e. a subject of authorization' % domain_obj
+            msg = '{0!s} is not a protected object, i.e. a subject of authorization'.format(domain_obj)
             raise Exception(msg)
         else:
             return protected_object
@@ -209,10 +207,9 @@ class PackageRole(UserObjectRole):
 
     def __repr__(self):
         if self.user:
-            return '<%s user="%s" role="%s" package="%s">' % \
-                (self.__class__.__name__, self.user.name, self.role, self.package.name)
+            return '<{0!s} user="{1!s}" role="{2!s}" package="{3!s}">'.format(self.__class__.__name__, self.user.name, self.role, self.package.name)
         else:
-            assert False, "%s is not a user" % self.__class__.__name__
+            assert False, "{0!s} is not a user".format(self.__class__.__name__)
 
 protected_objects[PackageRole.protected_object] = PackageRole
 
@@ -222,10 +219,9 @@ class GroupRole(UserObjectRole):
 
     def __repr__(self):
         if self.user:
-            return '<%s user="%s" role="%s" group="%s">' % \
-                (self.__class__.__name__, self.user.name, self.role, self.group.name)
+            return '<{0!s} user="{1!s}" role="{2!s}" group="{3!s}">'.format(self.__class__.__name__, self.user.name, self.role, self.group.name)
         else:
-            assert False, "%s is not a user" % self.__class__.__name__
+            assert False, "{0!s} is not a user".format(self.__class__.__name__)
 
 protected_objects[GroupRole.protected_object] = GroupRole
 
@@ -294,7 +290,7 @@ def setup_user_roles(_domain_object, visitor_roles, logged_in_roles, admins=[]):
         if admin is not None:
             assert isinstance(admin, _user.User), admin
             if admin.name in (PSEUDO_USER__LOGGED_IN, PSEUDO_USER__VISITOR):
-                raise NotRealUserException('Invalid user for domain object admin %r' % admin.name)
+                raise NotRealUserException('Invalid user for domain object admin {0!r}'.format(admin.name))
             for role in admin_roles:
                 add_user_to_role(admin, role, _domain_object)
 
@@ -308,7 +304,7 @@ def give_all_packages_default_user_roles():
         # weird - should already be in session but complains w/o this
         meta.Session.add(pkg)
         if len(pkg.roles) > 0:
-            print 'Skipping (already has roles): %s' % pkg.name
+            print 'Skipping (already has roles): {0!s}'.format(pkg.name)
             continue
         # work out the authors and make them admins
         admins = []
@@ -322,7 +318,7 @@ def give_all_packages_default_user_roles():
         # remove duplicates
         admins = list(set(admins))
         # gives default permissions
-        print 'Creating default user for for %s with admins %s' % (pkg.name, admins)
+        print 'Creating default user for for {0!s} with admins {1!s}'.format(pkg.name, admins)
         setup_default_user_roles(pkg, admins)
 
 # default user roles - used when the config doesn\'t specify them
@@ -338,15 +334,14 @@ _default_user_roles_cache = weakref.WeakKeyDictionary()
 def get_default_user_roles(_domain_object):
     # TODO: Should this func go in lib rather than model now?
     def _get_default_user_roles(_domain_object):
-        config_key = 'ckan.default_roles.%s' % obj_type
+        config_key = 'ckan.default_roles.{0!s}'.format(obj_type)
         user_roles_json = config.get(config_key)
         if user_roles_json is None:
             user_roles_str = default_default_user_roles[obj_type]
         else:
             user_roles_str = json.loads(user_roles_json) if user_roles_json else {}
         unknown_keys = set(user_roles_str.keys()) - set(('visitor', 'logged_in'))
-        assert not unknown_keys, 'Auth config for %r has unknown key %r' % \
-               (_domain_object, unknown_keys)
+        assert not unknown_keys, 'Auth config for {0!r} has unknown key {1!r}'.format(_domain_object, unknown_keys)
         user_roles_ = {}
         for user in ('visitor', 'logged_in'):
             roles_str = user_roles_str.get(user, [])

--- a/ckan/model/core.py
+++ b/ckan/model/core.py
@@ -19,7 +19,7 @@ class System(domain_object.DomainObject):
     name = 'system'
 
     def __unicode__(self):
-        return u'<%s>' % self.__class__.__name__
+        return u'<{0!s}>'.format(self.__class__.__name__)
 
     def purge(self):
         pass

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -103,13 +103,13 @@ class DomainObject(object):
         return self.__unicode__().encode('utf8')
 
     def __unicode__(self):
-        repr = u'<%s' % self.__class__.__name__
+        repr = u'<{0!s}'.format(self.__class__.__name__)
         table = orm.class_mapper(self.__class__).mapped_table
         for col in table.c:
             try:
-                repr += u' %s=%s' % (col.name, getattr(self, col.name))
+                repr += u' {0!s}={1!s}'.format(col.name, getattr(self, col.name))
             except Exception, inst:
-                repr += u' %s=%s' % (col.name, inst)
+                repr += u' {0!s}={1!s}'.format(col.name, inst)
 
         repr += '>'
         return repr

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -104,16 +104,15 @@ class Member(vdm.sqlalchemy.RevisionedObjectMixin,
     def __unicode__(self):
         # refer to objects by name, not ID, to help debugging
         if self.table_name == 'package':
-            table_info = 'package=%s' % meta.Session.query(_package.Package).\
-                get(self.table_id).name
+            table_info = 'package={0!s}'.format(meta.Session.query(_package.Package).\
+                get(self.table_id).name)
         elif self.table_name == 'group':
-            table_info = 'group=%s' % meta.Session.query(Group).\
-                get(self.table_id).name
+            table_info = 'group={0!s}'.format(meta.Session.query(Group).\
+                get(self.table_id).name)
         else:
-            table_info = 'table_name=%s table_id=%s' % (self.table_name,
+            table_info = 'table_name={0!s} table_id={1!s}'.format(self.table_name,
                                                         self.table_id)
-        return u'<Member group=%s %s capacity=%s state=%s>' % \
-               (self.group.name if self.group else repr(self.group),
+        return u'<Member group={0!s} {1!s} capacity={2!s} state={3!s}>'.format(self.group.name if self.group else repr(self.group),
                 table_info, self.capacity, self.state)
 
 
@@ -372,7 +371,7 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
         return sorted(result_list, cmp=ourcmp)
 
     def __repr__(self):
-        return '<Group %s>' % self.name
+        return '<Group {0!s}>'.format(self.name)
 
 meta.mapper(Group, group_table,
             extension=[vdm.sqlalchemy.Revisioner(group_revision_table), ], )

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -72,12 +72,12 @@ class LicenseRegister(object):
             response = urllib2.urlopen(license_url)
             response_body = response.read()
         except Exception, inst:
-            msg = "Couldn't connect to licenses service %r: %s" % (license_url, inst)
+            msg = "Couldn't connect to licenses service {0!r}: {1!s}".format(license_url, inst)
             raise Exception, msg
         try:
             license_data = json.loads(response_body)
         except Exception, inst:
-            msg = "Couldn't read response from licenses service %r: %s" % (response_body, inst)
+            msg = "Couldn't read response from licenses service {0!r}: {1!s}".format(response_body, inst)
             raise Exception, inst
         self._create_license_list(license_data, license_url)
 
@@ -87,7 +87,7 @@ class LicenseRegister(object):
         elif isinstance(license_data, list):
             self.licenses = [License(entity) for entity in license_data]
         else:
-            msg = "Licenses at %s must be dictionary or list" % license_url
+            msg = "Licenses at {0!s} must be dictionary or list".format(license_url)
             raise ValueError(msg)
 
     def __getitem__(self, key, default=Exception):
@@ -97,7 +97,7 @@ class LicenseRegister(object):
         if default != Exception:
             return default
         else:
-            raise KeyError, "License not found: %s" % key
+            raise KeyError, "License not found: {0!s}".format(key)
 
     def get(self, key, default=None):
         return self.__getitem__(key, default=default)

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -206,7 +206,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
                               for res in self.resources]
         site_url = config.get('ckan.site_url', None)
         if site_url:
-            _dict['ckan_url'] = '%s/dataset/%s' % (site_url, self.name)
+            _dict['ckan_url'] = '{0!s}/dataset/{1!s}'.format(site_url, self.name)
         _dict['relationships'] = [rel.as_dict(self, ref_package_by=ref_package_by) for rel in self.get_relationships()]
         _dict['metadata_modified'] = self.metadata_modified.isoformat() \
             if self.metadata_modified else None
@@ -233,7 +233,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
             subject = related_package
             object_ = self
         else:
-            raise KeyError, 'Package relationship type: %r' % type_
+            raise KeyError, 'Package relationship type: {0!r}'.format(type_)
 
         rels = self.get_relationships(with_package=related_package,
                                       type=type_, active=False, direction="forward")
@@ -356,7 +356,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
         elif type(license) == dict:
             self.license_id = license['id']
         else:
-            msg = "Value not a license object or entity: %s" % repr(license)
+            msg = "Value not a license object or entity: {0!s}".format(repr(license))
             raise Exception, msg
 
     license = property(get_license, set_license)
@@ -443,7 +443,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
                             display_id = to_obj_rev.key
                         else:
                             display_id = related_obj_id[:4]
-                        key = '%s-%s-%s' % (obj_class.__name__, display_id, col)
+                        key = '{0!s}-{1!s}-{2!s}'.format(obj_class.__name__, display_id, col)
                         results[key] = value_diff
         return results
 
@@ -535,7 +535,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
             d = {'package': dictization.table_dictize(self,
                 context={'model': ckan.model})}
             return activity.Activity(user_id, self.id, revision.id,
-                    "%s package" % activity_type, d)
+                    "{0!s} package".format(activity_type), d)
         except ckan.logic.NotFound:
             # This happens if this package is being purged and therefore has no
             # current revision.

--- a/ckan/model/package_relationship.py
+++ b/ckan/model/package_relationship.py
@@ -59,7 +59,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
             {'sibling':_('has sibling %s')}
 
     def __str__(self):
-        return '<%sPackageRelationship %s %s %s>' % ("*" if self.active != core.State.ACTIVE else "",
+        return '<{0!s}PackageRelationship {1!s} {2!s} {3!s}>'.format("*" if self.active != core.State.ACTIVE else "",
                                                      self.subject.name, self.type, self.object.name)
 
     def __repr__(self):
@@ -100,8 +100,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
             other_package = self.subject
         else:
             # FIXME do we want a more specific error
-            raise Exception('Package %s is not in this relationship: %s' % \
-                             (package, self))
+            raise Exception('Package {0!s} is not in this relationship: {1!s}'.format(package, self))
         return (type_str, other_package)
         
     @classmethod

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -86,7 +86,7 @@ class Resource(vdm.sqlalchemy.RevisionedObjectMixin,
             if value is not None:
                 setattr(self, field, value)
         if kwargs:
-            raise TypeError('unexpected keywords %s' % kwargs)
+            raise TypeError('unexpected keywords {0!s}'.format(kwargs))
 
     def as_dict(self, core_columns_only=False):
         _dict = OrderedDict()

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -129,8 +129,7 @@ class Tag(domain_object.DomainObject):
                 vocab = vocabulary.Vocabulary.get(vocab_id_or_name)
                 if vocab is None:
                     # The user specified an invalid vocab.
-                    raise ckan.logic.NotFound("could not find vocabulary '%s'"
-                            % vocab_id_or_name)
+                    raise ckan.logic.NotFound("could not find vocabulary '{0!s}'".format(vocab_id_or_name))
             else:
                 vocab = None
             tag = Tag.by_name(tag_id_or_name, vocab=vocab)
@@ -188,8 +187,7 @@ class Tag(domain_object.DomainObject):
             vocab = vocabulary.Vocabulary.get(vocab_id_or_name)
             if vocab is None:
                 # The user specified an invalid vocab.
-                raise ckan.logic.NotFound("could not find vocabulary '%s'"
-                        % vocab_id_or_name)
+                raise ckan.logic.NotFound("could not find vocabulary '{0!s}'".format(vocab_id_or_name))
             query = meta.Session.query(Tag).filter(Tag.vocabulary_id==vocab.id)
         else:
             query = meta.Session.query(Tag).filter(Tag.vocabulary_id == None)
@@ -213,7 +211,7 @@ class Tag(domain_object.DomainObject):
         return packages
 
     def __repr__(self):
-        return '<Tag %s>' % self.name
+        return '<Tag {0!s}>'.format(self.name)
 
 class PackageTag(vdm.sqlalchemy.RevisionedObjectMixin,
         vdm.sqlalchemy.StatefulObjectMixin,
@@ -226,7 +224,7 @@ class PackageTag(vdm.sqlalchemy.RevisionedObjectMixin,
             setattr(self, k, v)
 
     def __repr__(self):
-        s = u'<PackageTag package=%s tag=%s>' % (self.package.name, self.tag.name)
+        s = u'<PackageTag package={0!s} tag={1!s}>'.format(self.package.name, self.tag.name)
         return s.encode('utf8')
 
     def activity_stream_detail(self, activity_id, activity_type):

--- a/ckan/new_authz.py
+++ b/ckan/new_authz.py
@@ -45,11 +45,11 @@ class AuthFunctions:
         module_root = 'ckan.logic.auth'
 
         for auth_module_name in ['get', 'create', 'update', 'delete', 'patch']:
-            module_path = '%s.%s' % (module_root, auth_module_name,)
+            module_path = '{0!s}.{1!s}'.format(module_root, auth_module_name)
             try:
                 module = __import__(module_path)
             except ImportError:
-                log.debug('No auth module for action "%s"' % auth_module_name)
+                log.debug('No auth module for action "{0!s}"'.format(auth_module_name))
                 continue
 
             for part in module_path.split('.')[1:]:
@@ -76,7 +76,7 @@ class AuthFunctions:
             for name, auth_function in plugin.get_auth_functions().items():
                 if name in resolved_auth_function_plugins:
                     raise Exception(
-                        'The auth function %r is already implemented in %r' % (
+                        'The auth function {0!r} is already implemented in {1!r}'.format(
                             name,
                             resolved_auth_function_plugins[name]
                         )
@@ -175,7 +175,7 @@ def is_authorized(action, context, data_dict=None):
 
         return auth_function(context, data_dict)
     else:
-        raise ValueError(_('Authorization function not found: %s' % action))
+        raise ValueError(_('Authorization function not found: {0!s}'.format(action)))
 
 
 # these are the permissions that roles have
@@ -200,7 +200,7 @@ def _trans_role_member():
 
 def trans_role(role):
     module = sys.modules[__name__]
-    return getattr(module, '_trans_role_%s' % role)()
+    return getattr(module, '_trans_role_{0!s}'.format(role))()
 
 
 def roles_list():

--- a/ckan/new_tests/controllers/test_api.py
+++ b/ckan/new_tests/controllers/test_api.py
@@ -14,7 +14,7 @@ class TestApiController(helpers.FunctionalTestBase):
         app = self._get_test_app()
         org_url = '/api/action/tag_delete'
         data_dict = {'id': u'Delta symbol: \u0394'}  # unicode gets rec'd ok
-        postparams = '%s=1' % json.dumps(data_dict)
+        postparams = '{0!s}=1'.format(json.dumps(data_dict))
         response = app.post(url=org_url, params=postparams, status=404)
         # The unicode is backslash encoded (because that is the default when
         # you do str(exception) )

--- a/ckan/new_tests/helpers.py
+++ b/ckan/new_tests/helpers.py
@@ -33,10 +33,10 @@ try:
 except ImportError:
     # Python 2.6 doesn't have these, so define them here
     def assert_in(a, b, msg=None):
-        assert a in b, msg or '%r was not in %r' % (a, b)
+        assert a in b, msg or '{0!r} was not in {1!r}'.format(a, b)
 
     def assert_not_in(a, b, msg=None):
-        assert a not in b, msg or '%r was in %r' % (a, b)
+        assert a not in b, msg or '{0!r} was in {1!r}'.format(a, b)
 
 
 def reset_db():

--- a/ckan/new_tests/lib/dictization/test_model_dictize.py
+++ b/ckan/new_tests/lib/dictization/test_model_dictize.py
@@ -320,12 +320,11 @@ class TestPackageDictize:
     def assert_equals_expected(self, expected_dict, result_dict):
         result_dict = self.remove_changable_values(result_dict)
         superfluous_keys = set(result_dict) - set(expected_dict)
-        assert not superfluous_keys, 'Did not expect key: %s' % \
-            ' '.join(('%s=%s' % (k, result_dict[k]) for k in superfluous_keys))
+        assert not superfluous_keys, 'Did not expect key: {0!s}'.format( \
+            ' '.join(('{0!s}={1!s}'.format(k, result_dict[k]) for k in superfluous_keys)))
         for key in expected_dict:
             assert expected_dict[key] == result_dict[key], \
-                '%s=%s should be %s' % \
-                (key, result_dict[key], expected_dict[key])
+                '{0!s}={1!s} should be {2!s}'.format(key, result_dict[key], expected_dict[key])
 
     def test_package_dictize_basic(self):
         dataset = factories.Dataset(name='test_dataset_dictize',
@@ -505,7 +504,6 @@ class TestPackageDictize:
 
 def assert_equal_for_keys(dict1, dict2, *keys):
     for key in keys:
-        assert key in dict1, 'Dict 1 misses key "%s"' % key
-        assert key in dict2, 'Dict 2 misses key "%s"' % key
-        assert dict1[key] == dict2[key], '%s != %s (key=%s)' % \
-            (dict1[key], dict2[key], key)
+        assert key in dict1, 'Dict 1 misses key "{0!s}"'.format(key)
+        assert key in dict2, 'Dict 2 misses key "{0!s}"'.format(key)
+        assert dict1[key] == dict2[key], '{0!s} != {1!s} (key={2!s})'.format(dict1[key], dict2[key], key)

--- a/ckan/new_tests/lib/search/test_index.py
+++ b/ckan/new_tests/lib/search/test_index.py
@@ -23,7 +23,7 @@ class TestSearchIndex(object):
 
         cls.solr_client = search.make_connection()
 
-        cls.fq = " +site_id:\"%s\" " % config['ckan.site_id']
+        cls.fq = " +site_id:\"{0!s}\" ".format(config['ckan.site_id'])
 
         cls.package_index = search.PackageSearchIndex()
 

--- a/ckan/new_tests/model/test_resource.py
+++ b/ckan/new_tests/model/test_resource.py
@@ -68,5 +68,5 @@ class TestResource(object):
         resources = Resource.get_all_without_views(['FORMAT'])
 
         length = len(resources)
-        assert length == 1, 'Expected 1 resource, but got %d' % length
+        assert length == 1, 'Expected 1 resource, but got {0:d}'.format(length)
         assert_equals([resources[0].id], [resource_id])

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -143,7 +143,7 @@ def load(*plugins):
     observers = PluginImplementations(interfaces.IPluginObserver)
     for plugin in plugins:
         if plugin in _PLUGINS:
-            raise Exception('Plugin `%s` already loaded' % plugin)
+            raise Exception('Plugin `{0!s}` already loaded'.format(plugin))
 
         service = _get_service(plugin)
         for observer_plugin in observers:
@@ -194,7 +194,7 @@ def unload(*plugins):
             if plugin in _PLUGINS_SERVICE:
                 del _PLUGINS_SERVICE[plugin]
         else:
-            raise Exception('Cannot unload plugin `%s`' % plugin)
+            raise Exception('Cannot unload plugin `{0!s}`'.format(plugin))
 
         service = _get_service(plugin)
         for observer_plugin in observers:

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -200,7 +200,7 @@ content type, cookies, etc.
         # check contents list correct
         errors = set(t).symmetric_difference(set(self.contents))
         if errors:
-            raise Exception('Plugin toolkit error %s not matching' % errors)
+            raise Exception('Plugin toolkit error {0!s} not matching'.format(errors))
 
     # wrappers
     # Wrapper for the render_snippet function as it uses keywords rather than
@@ -345,10 +345,9 @@ content type, cookies, etc.
         if not cls._check_ckan_version(min_version=min_version,
                                        max_version=max_version):
             if not max_version:
-                error = 'Requires ckan version %s or higher' % min_version
+                error = 'Requires ckan version {0!s} or higher'.format(min_version)
             else:
-                error = 'Requires ckan version between %s and %s' % \
-                            (min_version, max_version)
+                error = 'Requires ckan version between {0!s} and {1!s}'.format(min_version, max_version)
             raise CkanVersionException(error)
 
     def __getattr__(self, name):
@@ -360,7 +359,7 @@ content type, cookies, etc.
         else:
             if name == '__bases__':
                 return self.__class__.__bases__
-            raise AttributeError('`%s` not found in plugins toolkit' % name)
+            raise AttributeError('`{0!s}` not found in plugins toolkit'.format(name))
 
     def __dir__(self):
         if not self._toolkit:

--- a/ckan/tests/__init__.py
+++ b/ckan/tests/__init__.py
@@ -79,12 +79,12 @@ class BaseCase(object):
         import commands
         (status, output) = commands.getstatusoutput(cmd)
         if status:
-            raise Exception, "Couldn't execute cmd: %s: %s" % (cmd, output)
+            raise Exception, "Couldn't execute cmd: {0!s}: {1!s}".format(cmd, output)
 
     @classmethod
     def _paster(cls, cmd, config_path_rel):
         config_path = os.path.join(config['here'], config_path_rel)
-        cls._system('paster --plugin ckan %s --config=%s' % (cmd, config_path))
+        cls._system('paster --plugin ckan {0!s} --config={1!s}'.format(cmd, config_path))
 
 
 class CommonFixtureMethods(BaseCase):
@@ -182,16 +182,16 @@ class CommonFixtureMethods(BaseCase):
 class CheckMethods(BaseCase):
 
     def assert_true(self, value):
-        assert value, "Not true: '%s'" % value
+        assert value, "Not true: '{0!s}'".format(value)
 
     def assert_false(self, value):
-        assert not value, "Not false: '%s'" % value
+        assert not value, "Not false: '{0!s}'".format(value)
 
     def assert_equal(self, value1, value2):
-        assert value1 == value2, 'Not equal: %s' % ((value1, value2),)
+        assert value1 == value2, 'Not equal: {0!s}'.format((value1, value2))
 
     def assert_isinstance(self, value, check):
-        assert isinstance(value, check), 'Not an instance: %s' % ((value, check),)
+        assert isinstance(value, check), 'Not an instance: {0!s}'.format((value, check))
 
     def assert_raises(self, exception_class, callable, *args, **kwds):
         try:
@@ -199,19 +199,19 @@ class CheckMethods(BaseCase):
         except exception_class:
             pass
         else:
-            assert False, "Didn't raise '%s' when calling: %s with %s" % (exception_class, callable, (args, kwds))
+            assert False, "Didn't raise '{0!s}' when calling: {1!s} with {2!s}".format(exception_class, callable, (args, kwds))
 
     def assert_contains(self, sequence, item):
-        assert item in sequence, "Sequence %s does not contain item: %s" % (sequence, item)
+        assert item in sequence, "Sequence {0!s} does not contain item: {1!s}".format(sequence, item)
 
     def assert_missing(self, sequence, item):
-        assert item not in sequence, "Sequence %s does contain item: %s" % (sequence, item)
+        assert item not in sequence, "Sequence {0!s} does contain item: {1!s}".format(sequence, item)
 
     def assert_len(self, sequence, count):
-        assert len(sequence) == count, "Length of sequence %s was not %s." % (sequence, count)
+        assert len(sequence) == count, "Length of sequence {0!s} was not {1!s}.".format(sequence, count)
 
     def assert_isinstance(self, object, kind):
-        assert isinstance(object, kind), "Object %s is not an instance of %s." % (object, kind)
+        assert isinstance(object, kind), "Object {0!s} is not an instance of {1!s}.".format(object, kind)
 
 
 class TestCase(CommonFixtureMethods, CheckMethods, BaseCase):
@@ -271,8 +271,8 @@ class CkanServerCase(BaseCase):
     def _stop_ckan_server(process):
         pid = process.pid
         pid = int(pid)
-        if os.system("kill -9 %d" % pid):
-            raise Exception, "Can't kill foreign CKAN instance (pid: %d)." % pid
+        if os.system("kill -9 {0:d}".format(pid)):
+            raise Exception, "Can't kill foreign CKAN instance (pid: {0:d}).".format(pid)
 
 
 class TestController(CommonFixtureMethods, CkanServerCase, WsgiAppCase, BaseCase):
@@ -359,9 +359,9 @@ try:
     from nose.tools import assert_in, assert_not_in
 except ImportError:
     def assert_in(a, b, msg=None):
-        assert a in b, msg or '%r was not in %r' % (a, b)
+        assert a in b, msg or '{0!r} was not in {1!r}'.format(a, b)
     def assert_not_in(a, b, msg=None):
-        assert a not in b, msg or '%r was in %r' % (a, b)
+        assert a not in b, msg or '{0!r} was in {1!r}'.format(a, b)
 
 class TestRoles:
     @classmethod
@@ -392,7 +392,7 @@ class TestRoles:
                 else:
                     pretty_role[key] = value
             if one_per_line:
-                pretty_role = '"%s" is "%s" on "%s"' % (
+                pretty_role = '"{0!s}" is "{1!s}" on "{2!s}"'.format(
                     pretty_role.get('user'),
                     pretty_role['role'],
                     pretty_role.get('package') or pretty_role.get('group') or pretty_role.get('context'))

--- a/ckan/tests/functional/api/base.py
+++ b/ckan/tests/functional/api/base.py
@@ -43,7 +43,7 @@ class ApiTestCase(object):
         return response
 
     def post(self, offset, data, status=[200,201], *args, **kwds):
-        params = '%s=1' % url_escape(self.dumps(data))
+        params = '{0!s}=1'.format(url_escape(self.dumps(data)))
         if 'extra_environ' in kwds:
             self.extra_environ = kwds['extra_environ']
         response = self.app.post(offset, params=params, status=status,
@@ -83,8 +83,8 @@ class ApiTestCase(object):
         assert self.api_version != None, "API version is missing."
         base = '/api'
         if self.api_version:
-            base += '/%s' % self.api_version
-        utf8_encoded = (u'%s%s' % (base, path)).encode('utf8')
+            base += '/{0!s}'.format(self.api_version)
+        utf8_encoded = (u'{0!s}{1!s}'.format(base, path)).encode('utf8')
         url_encoded = urllib.quote(utf8_encoded)
         return url_encoded
 
@@ -102,7 +102,7 @@ class ApiTestCase(object):
         assert 'annakarenina.com/download' in msg, msg
         assert '"plain text"' in msg, msg
         assert '"Index of the novel"' in msg, msg
-        assert '"id": "%s"' % self.anna.id in msg, msg
+        assert '"id": "{0!s}"'.format(self.anna.id) in msg, msg
         expected = '"groups": ['
         assert expected in msg, (expected, msg)
         expected = self.group_ref_from_name('roger')
@@ -139,7 +139,7 @@ class ApiTestCase(object):
         expected_pkgs = set([self.package_ref_from_name('annakarenina'),
                              self.package_ref_from_name('warandpeace')])
         differences = expected_pkgs ^ pkgs
-        assert not differences, '%r != %r' % (pkgs, expected_pkgs)
+        assert not differences, '{0!r} != {1!r}'.format(pkgs, expected_pkgs)
 
     def assert_msg_represents_flexible_tag(self, msg):
         """
@@ -152,7 +152,7 @@ class ApiTestCase(object):
         expected_pkgs = set([self.package_ref_from_name('annakarenina'),
                              self.package_ref_from_name('warandpeace')])
         differences = expected_pkgs ^ pkgs
-        assert not differences, '%r != %r' % (pkgs, expected_pkgs)
+        assert not differences, '{0!r} != {1!r}'.format(pkgs, expected_pkgs)
 
     def data_from_res(self, res):
         return self.loads(res.body)
@@ -185,7 +185,7 @@ class ApiTestCase(object):
         try:
             return json.loads(chars)
         except ValueError, inst:
-            raise Exception, "Couldn't loads string '%s': %s" % (chars, inst)
+            raise Exception, "Couldn't loads string '{0!s}': {1!s}".format(chars, inst)
 
     def assert_json_response(self, res, expected_in_body=None):
         content_type = res.header_dict['Content-Type']
@@ -194,8 +194,7 @@ class ApiTestCase(object):
         if expected_in_body:
             assert expected_in_body in res_json or \
                    expected_in_body in str(res_json), \
-                   'Expected to find %r in JSON response %r' % \
-                   (expected_in_body, res_json)
+                   'Expected to find {0!r} in JSON response {1!r}'.format(expected_in_body, res_json)
 
 class Api1and2TestCase(object):
     ''' Utils for v1 and v2 API.
@@ -208,7 +207,7 @@ class Api1and2TestCase(object):
         else:
             # Package Entity
             package_ref = self.package_ref_from_name(package_name)
-            return self.offset('/rest/dataset/%s' % package_ref)
+            return self.offset('/rest/dataset/{0!s}'.format(package_ref))
 
     def group_offset(self, group_name=None):
         if group_name is None:
@@ -217,7 +216,7 @@ class Api1and2TestCase(object):
         else:
             # Group Entity
             group_ref = self.group_ref_from_name(group_name)
-            return self.offset('/rest/group/%s' % group_ref)
+            return self.offset('/rest/group/{0!s}'.format(group_ref))
 
     def group_ref_from_name(self, group_name):
         group = self.get_group_by_name(unicode(group_name))
@@ -236,7 +235,7 @@ class Api1and2TestCase(object):
             return self.offset('/rest/revision')
         else:
             # Revision Entity
-            return self.offset('/rest/revision/%s' % revision_id)
+            return self.offset('/rest/revision/{0!s}'.format(revision_id))
 
     def rating_offset(self, package_name=None):
         if package_name is None:
@@ -245,7 +244,7 @@ class Api1and2TestCase(object):
         else:
             # Revision Entity
             package_ref = self.package_ref_from_name(package_name)
-            return self.offset('/rest/rating/%s' % package_ref)
+            return self.offset('/rest/rating/{0!s}'.format(package_ref))
 
     def anna_offset(self, postfix=''):
         return self.package_offset('annakarenina') + postfix
@@ -257,7 +256,7 @@ class Api1and2TestCase(object):
         else:
             # Tag Entity
             tag_ref = self.tag_ref_from_name(tag_name)
-            return self.offset('/rest/tag/%s' % tag_ref)
+            return self.offset('/rest/tag/{0!s}'.format(tag_ref))
 
     def tag_ref_from_name(self, tag_name):
         tag = self.get_tag_by_name(unicode(tag_name))

--- a/ckan/tests/functional/api/model/test_group.py
+++ b/ckan/tests/functional/api/model/test_group.py
@@ -33,7 +33,7 @@ class GroupsTestCase(BaseModelApiTestCase):
 
     def test_register_post_ok(self):
         data = self.testgroupvalues
-        postparams = '%s=1' % self.dumps(data)
+        postparams = '{0!s}=1'.format(self.dumps(data))
         offset = self.group_offset()
         res = self.app.post(offset, params=postparams,
                             status=self.STATUS_201_CREATED,
@@ -68,7 +68,7 @@ class GroupsTestCase(BaseModelApiTestCase):
 
         # Test Group Register Post 409 (conflict - create duplicate group).
         offset = self.group_offset()
-        postparams = '%s=1' % self.dumps(self.testgroupvalues)
+        postparams = '{0!s}=1'.format(self.dumps(self.testgroupvalues))
         res = self.app.post(offset, params=postparams,
                             status=self.STATUS_409_CONFLICT,
                             extra_environ=self.extra_environ)
@@ -89,7 +89,7 @@ class GroupsTestCase(BaseModelApiTestCase):
         offset = self.group_offset(self.david.name)
         res = self.app.get(offset, status=self.STATUS_200_OK)
         data = self.loads(res.body)
-        postparams = '%s=1' % self.dumps(data)
+        postparams = '{0!s}=1'.format(self.dumps(data))
         res = self.app.post(offset, params=postparams,
                             status=self.STATUS_200_OK,
                             extra_environ=self.admin_extra_environ)
@@ -105,7 +105,7 @@ class GroupsTestCase(BaseModelApiTestCase):
         group = model.Group.by_name(self.testgroupvalues['name'])
         if not group:
             offset = self.offset('/rest/group')
-            postparams = '%s=1' % self.dumps(self.testgroupvalues)
+            postparams = '{0!s}=1'.format(self.dumps(self.testgroupvalues))
             res = self.app.post(offset, params=postparams, status=[201],
                     extra_environ=self.extra_environ)
             model.Session.remove()
@@ -119,7 +119,7 @@ class GroupsTestCase(BaseModelApiTestCase):
         group_vals = {'name':u'somethingnew', 'title':u'newtesttitle',
                       'packages':[u'annakarenina']}
         offset = self.group_offset(self.testgroupvalues['name'])
-        postparams = '%s=1' % self.dumps(group_vals)
+        postparams = '{0!s}=1'.format(self.dumps(group_vals))
         res = self.app.post(offset, params=postparams, status=[200],
                             extra_environ=self.extra_environ)
         model.Session.remove()
@@ -161,7 +161,7 @@ class GroupsTestCase(BaseModelApiTestCase):
         # edit first group to have dupname
         group_vals = {'name':dupname}
         offset = self.group_offset(self.testgroupvalues['name'])
-        postparams = '%s=1' % self.dumps(group_vals)
+        postparams = '{0!s}=1'.format(self.dumps(group_vals))
         res = self.app.post(offset, params=postparams, status=[409],
                             extra_environ=self.admin_extra_environ)
         self.assert_json_response(res, 'Group name already exists')

--- a/ckan/tests/functional/api/model/test_package.py
+++ b/ckan/tests/functional/api/model/test_package.py
@@ -52,7 +52,7 @@ class PackagesTestCase(BaseModelApiTestCase):
     def test_register_post_ok(self):
         assert not self.get_package_by_name(self.package_fixture_data['name'])
         offset = self.package_offset()
-        postparams = '%s=1' % self.dumps(self.package_fixture_data)
+        postparams = '{0!s}=1'.format(self.dumps(self.package_fixture_data))
         res = self.app.post(offset, params=postparams,
                             status=self.STATUS_201_CREATED,
                             extra_environ=self.admin_extra_environ)
@@ -90,8 +90,7 @@ class PackagesTestCase(BaseModelApiTestCase):
                     expected_resource_extras = expected_resource[key].items()
                     for expected_extras_key, expected_extras_value in expected_resource_extras:
                         package_resource_value = package_resource_extras[expected_extras_key],\
-                         'Package:%r Extras:%r Expected_extras:%r' % \
-                         (self.package_fixture_data['name'],
+                         'Package:{0!r} Extras:{1!r} Expected_extras:{2!r}'.format(self.package_fixture_data['name'],
                           package_resource_extras, expected_resource)
                 else:
                     package_resource_value = getattr(package_resource, key, None)
@@ -106,18 +105,18 @@ class PackagesTestCase(BaseModelApiTestCase):
         res = self.app.get(offset, status=self.STATUS_200_OK)
         # Todo: Instead loads() the data and then check actual values.
         assert self.package_fixture_data['name'] in res, res
-        assert '"license_id": "%s"' % self.package_fixture_data['license_id'] in res, res
+        assert '"license_id": "{0!s}"'.format(self.package_fixture_data['license_id']) in res, res
         assert self.package_fixture_data['tags'][0] in res, res
         assert self.package_fixture_data['tags'][1] in res, res
         assert '"extras": {' in res, res
         for key, value in self.package_fixture_data['extras'].items():
-            assert '"%s": "%s"' % (key, value) in res, res
+            assert '"{0!s}": "{1!s}"'.format(key, value) in res, res
 
         model.Session.remove()
 
         # Test Packages Register Post 409 (conflict - create duplicate package).
         offset = self.package_offset()
-        postparams = '%s=1' % self.dumps(self.package_fixture_data)
+        postparams = '{0!s}=1'.format(self.dumps(self.package_fixture_data))
         res = self.app.post(offset, params=postparams, status=self.STATUS_409_CONFLICT,
                 extra_environ=self.admin_extra_environ)
         model.Session.remove()
@@ -241,13 +240,13 @@ class PackagesTestCase(BaseModelApiTestCase):
             'resources':[u'should_be_a_dict'],
         }
         offset = self.offset('/rest/dataset')
-        postparams = '%s=1' % self.dumps(test_params)
+        postparams = '{0!s}=1'.format(self.dumps(test_params))
         res = self.app.post(offset, params=postparams, status=self.STATUS_400_BAD_REQUEST,
                 extra_environ=self.admin_extra_environ)
 
     def test_register_post_denied(self):
         offset = self.offset('/rest/dataset')
-        postparams = '%s=1' % self.dumps(self.package_fixture_data)
+        postparams = '{0!s}=1'.format(self.dumps(self.package_fixture_data))
         res = self.app.post(offset, params=postparams, status=self.STATUS_403_ACCESS_DENIED)
 
     def test_register_post_indexerror(self):
@@ -282,7 +281,7 @@ class PackagesTestCase(BaseModelApiTestCase):
     def test_entity_get_ok(self):
         package_refs = [self.anna.name, self.anna.id]
         for ref in package_refs:
-            offset = self.offset('/rest/dataset/%s' % ref)
+            offset = self.offset('/rest/dataset/{0!s}'.format(ref))
             res = self.app.get(offset, status=self.STATUS_200_OK)
             self.assert_msg_represents_anna(msg=res.body)
 
@@ -307,7 +306,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         res = self.app.get(offset, status=self.STATUS_200_OK)
         data = self.loads(res.body)
 
-        postparams = '%s=1' % self.dumps(data)
+        postparams = '{0!s}=1'.format(self.dumps(data))
         res = self.app.post(offset, params=postparams,
                             status=self.STATUS_200_OK,
                             extra_environ=self.admin_extra_environ)
@@ -323,7 +322,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         # change name and create a new package
         data['name'] = u'newpkg'
         data['id'] = None # ensure this doesn't clash or you get 409 error
-        postparams = '%s=1' % self.dumps(data)
+        postparams = '{0!s}=1'.format(self.dumps(data))
         # use russianfan now because he has rights to add this package to
         # the 'david' group.
         extra_environ = {'REMOTE_USER': 'testsysadmin'}
@@ -343,7 +342,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         res = self.app.get(offset, status=self.STATUS_200_OK)
         data = self.loads(res.body)
         data['id'] = 'illegally changed value'
-        postparams = '%s=1' % self.dumps(data)
+        postparams = '{0!s}=1'.format(self.dumps(data))
         res = self.app.post(offset, params=postparams,
                             status=self.STATUS_409_CONFLICT,
                             extra_environ=self.admin_extra_environ)
@@ -352,7 +351,7 @@ class PackagesTestCase(BaseModelApiTestCase):
 
     def test_entity_update_denied(self):
         offset = self.anna_offset()
-        postparams = '%s=1' % self.dumps(self.package_fixture_data)
+        postparams = '{0!s}=1'.format(self.dumps(self.package_fixture_data))
         res = self.app.post(offset, params=postparams, status=self.STATUS_403_ACCESS_DENIED)
 
     def test_entity_delete_denied(self):
@@ -361,7 +360,7 @@ class PackagesTestCase(BaseModelApiTestCase):
 
     def test_09_update_package_entity_not_found(self):
         offset = self.offset('/rest/dataset/22222')
-        postparams = '%s=1' % self.dumps(self.package_fixture_data)
+        postparams = '{0!s}=1'.format(self.dumps(self.package_fixture_data))
         res = self.app.post(offset, params=postparams,
                             status=self.STATUS_404_NOT_FOUND,
                             extra_environ=self.admin_extra_environ)
@@ -415,8 +414,8 @@ class PackagesTestCase(BaseModelApiTestCase):
         # because you should be able to specify the package both ways round
         # for both versions of the API.
         package_ref = getattr(pkg, package_ref_attribute)
-        offset = self.offset('/rest/dataset/%s' % package_ref)
-        params = '%s=1' % self.dumps(new_fixture_data)
+        offset = self.offset('/rest/dataset/{0!s}'.format(package_ref))
+        params = '{0!s}=1'.format(self.dumps(new_fixture_data))
         method_func = getattr(self.app, method_str)
         res = method_func(offset, params=params, status=self.STATUS_200_OK,
                           extra_environ=self.admin_extra_environ)
@@ -441,9 +440,9 @@ class PackagesTestCase(BaseModelApiTestCase):
             # - tags
             package_tagnames = [tag.name for tag in package.get_tags()]
             for tagname in new_fixture_data['tags']:
-                assert tagname in package_tagnames, 'tag %r not in %r' % (tagname, package_tagnames)
+                assert tagname in package_tagnames, 'tag {0!r} not in {1!r}'.format(tagname, package_tagnames)
             # - resources
-            assert len(package.resources), "Package has no resources: %s" % package
+            assert len(package.resources), "Package has no resources: {0!s}".format(package)
             self.assert_equal(len(package.resources), 2)
             resource = package.resources[0]
             self.assert_equal(resource.url, u'http://blah.com/file2.xml')
@@ -507,8 +506,8 @@ class PackagesTestCase(BaseModelApiTestCase):
         }
         self.create_package_with_admin_user(old_fixture_data)
         pkg = self.get_package_by_name(old_fixture_data['name'])
-        offset = self.offset('/rest/dataset/%s' % pkg.name)
-        params = '%s=1' % self.dumps(new_fixture_data)
+        offset = self.offset('/rest/dataset/{0!s}'.format(pkg.name))
+        params = '{0!s}=1'.format(self.dumps(new_fixture_data))
         res = self.app.post(offset, params=params,
                             status=self.STATUS_409_CONFLICT,
                             extra_environ=self.admin_extra_environ)
@@ -532,7 +531,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         }
         self.create_package_with_admin_user(old_fixture_data)
         offset = self.package_offset(old_fixture_data['name'])
-        params = '%s=1' % self.dumps(new_fixture_data)
+        params = '{0!s}=1'.format(self.dumps(new_fixture_data))
         res = self.app.post(offset, params=params, status=self.STATUS_200_OK,
                             extra_environ=self.admin_extra_environ)
 
@@ -566,7 +565,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         }
         self.create_package_with_admin_user(old_fixture_data)
         offset = self.package_offset(old_fixture_data['name'])
-        params = '%s=1' % self.dumps(new_fixture_data)
+        params = '{0!s}=1'.format(self.dumps(new_fixture_data))
         res = self.app.post(offset, params=params, status=self.STATUS_200_OK,
                             extra_environ=self.admin_extra_environ)
 
@@ -597,7 +596,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         }
         self.create_package_with_admin_user(old_fixture_data)
         offset = self.package_offset(name)
-        params = '%s=1' % self.dumps(new_fixture_data)
+        params = '{0!s}=1'.format(self.dumps(new_fixture_data))
         res = self.app.post(offset, params=params, status=self.STATUS_200_OK,
                             extra_environ=self.admin_extra_environ)
 
@@ -610,7 +609,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         assert len(package.get_tags()) == 1, package.get_tags()
 
         # now reinstate the tag
-        params = '%s=1' % self.dumps(old_fixture_data)
+        params = '{0!s}=1'.format(self.dumps(old_fixture_data))
         res = self.app.post(offset, params=params, status=self.STATUS_200_OK,
                             extra_environ=self.admin_extra_environ)
         pkg = self.loads(res.body)
@@ -678,7 +677,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         }
         self.create_package_with_admin_user(old_fixture_data)
         offset = self.package_offset(old_fixture_data['name'])
-        params = '%s=1' % self.dumps(new_fixture_data)
+        params = '{0!s}=1'.format(self.dumps(new_fixture_data))
         res = self.app.post(offset, params=params, status=self.STATUS_200_OK,
                             extra_environ=self.admin_extra_environ)
 
@@ -724,13 +723,13 @@ class PackagesTestCase(BaseModelApiTestCase):
     def test_entity_delete_not_found(self):
         package_name = u'random_one'
         assert not model.Session.query(model.Package).filter_by(name=package_name).count()
-        offset = self.offset('/rest/dataset/%s' % package_name)
+        offset = self.offset('/rest/dataset/{0!s}'.format(package_name))
         res = self.app.delete(offset, status=self.STATUS_404_NOT_FOUND,
                               extra_environ=self.admin_extra_environ)
 
     def test_package_revisions(self):
         # check original revision
-        res = self.app.get(self.offset('/rest/dataset/%s/revisions' % 'annakarenina'))
+        res = self.app.get(self.offset('/rest/dataset/{0!s}/revisions'.format('annakarenina')))
         revisions = res.json
         assert len(revisions) == 1, len(revisions)
         expected_keys = set(('id', 'message', 'author', 'timestamp', 'approved_timestamp'))
@@ -744,7 +743,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         model.repo.commit_and_remove()
 
         # check new revision is there
-        res = self.app.get(self.offset('/rest/dataset/%s/revisions' % 'annakarenina'))
+        res = self.app.get(self.offset('/rest/dataset/{0!s}/revisions'.format('annakarenina')))
         revisions = res.json
         assert len(revisions) == 2, len(revisions)
 
@@ -758,7 +757,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         model.repo.commit_and_remove()
 
         # check new revision is there
-        res = self.app.get(self.offset('/rest/dataset/%s/revisions' % 'annakarenina'))
+        res = self.app.get(self.offset('/rest/dataset/{0!s}/revisions'.format('annakarenina')))
         revisions = res.json
         assert len(revisions) == 3, len(revisions)
 
@@ -800,7 +799,7 @@ class TestPackagesVersion1(Version1TestCase, PackagesTestCase):
             'download_url':u'ftp://ftp.monash.edu.au/pub/nihongo/JMdict.gz',
             }
         offset = self.package_offset()
-        postparams = '%s=1' % self.dumps(test_params)
+        postparams = '{0!s}=1'.format(self.dumps(test_params))
         res = self.app.post(offset, params=postparams,
                             extra_environ=self.admin_extra_environ)
         model.Session.remove()
@@ -831,7 +830,7 @@ class TestPackagesVersion1(Version1TestCase, PackagesTestCase):
         # edit it
         pkg_vals = {'download_url':u'newurl'}
         offset = self.package_offset(test_params['name'])
-        postparams = '%s=1' % self.dumps(pkg_vals)
+        postparams = '{0!s}=1'.format(self.dumps(pkg_vals))
         res = self.app.post(offset, params=postparams, status=[200],
                             extra_environ=self.admin_extra_environ)
         model.Session.remove()

--- a/ckan/tests/functional/api/model/test_ratings.py
+++ b/ckan/tests/functional/api/model/test_ratings.py
@@ -55,7 +55,7 @@ class RatingsTestCase(BaseModelApiTestCase):
         rating_opts = {'package':u'warandpeace',
                        'rating':5}
         pkg_name = rating_opts['package']
-        postparams = '%s=1' % self.dumps(rating_opts)
+        postparams = '{0!s}=1'.format(self.dumps(rating_opts))
         res = self.app.post(offset, params=postparams, status=[201],
                 extra_environ=self.extra_environ)
         model.Session.remove()
@@ -68,14 +68,14 @@ class RatingsTestCase(BaseModelApiTestCase):
         offset = self.package_offset(pkg_name)
         res = self.app.get(offset, status=[200])
         assert pkg_name in res, res
-        assert '"ratings_average": %s.0' % rating_opts['rating'] in res, res
+        assert '"ratings_average": {0!s}.0'.format(rating_opts['rating']) in res, res
         assert '"ratings_count": 1' in res, res
         
         model.Session.remove()
         
         # Rerate package
         offset = self.rating_offset()
-        postparams = '%s=1' % self.dumps(rating_opts)
+        postparams = '{0!s}=1'.format(self.dumps(rating_opts))
         res = self.app.post(offset, params=postparams, status=[201],
                 extra_environ=self.extra_environ)
         model.Session.remove()
@@ -89,7 +89,7 @@ class RatingsTestCase(BaseModelApiTestCase):
         offset = self.rating_offset()
         rating_opts = {'package':u'warandpeace',
                        'rating':0}
-        postparams = '%s=1' % self.dumps(rating_opts)
+        postparams = '{0!s}=1'.format(self.dumps(rating_opts))
         res = self.app.post(offset, params=postparams, status=[409],
                             extra_environ=self.extra_environ)
         self.assert_json_response(res, 'rating')

--- a/ckan/tests/functional/api/model/test_relationships.py
+++ b/ckan/tests/functional/api/model/test_relationships.py
@@ -36,19 +36,16 @@ class RelationshipsTestCase(BaseModelApiTestCase):
         package_1_ref = self.package_ref_from_name(package_1_name)
         if package_2_name is None:
             if not relationship_type:
-                return self.offset('/rest/dataset/%s/relationships' % \
-                                   package_1_ref)
+                return self.offset('/rest/dataset/{0!s}/relationships'.format( \
+                                   package_1_ref))
             else:
-                return self.offset('/rest/dataset/%s/%s' %
-                                   (package_1_ref, relationship_type))
+                return self.offset('/rest/dataset/{0!s}/{1!s}'.format(package_1_ref, relationship_type))
         else:
             package_2_ref = self.package_ref_from_name(package_2_name)
             if not relationship_type:
-                return self.offset('/rest/dataset/%s/relationships/%s' % \
-                                   (package_1_ref, package_2_ref))
+                return self.offset('/rest/dataset/{0!s}/relationships/{1!s}'.format(package_1_ref, package_2_ref))
             else:
-                return self.offset('/rest/dataset/%s/%s/%s' % \
-                                   (package_1_ref,
+                return self.offset('/rest/dataset/{0!s}/{1!s}/{2!s}'.format(package_1_ref,
                                     relationship_type,
                                     package_2_ref))
 
@@ -131,7 +128,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
         data = {'type': 'links_to',
                 'object': 'warandpeace',
                 'comment':self.comment}
-        postparams = '%s=1' % self.dumps(data)
+        postparams = '{0!s}=1'.format(self.dumps(data))
         res = self.app.post(offset, params=postparams, status=[201],
                             extra_environ=self.extra_environ)
         # Check the response
@@ -178,7 +175,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
 
     def test_create_relationship_unknown(self):
         offset = self.relationship_offset('annakarenina', 'unheard_of_type', 'warandpeace')
-        postparams = '%s=1' % self.dumps({'comment':self.comment})
+        postparams = '{0!s}=1'.format(self.dumps({'comment':self.comment}))
         res = self.app.post(offset, params=postparams, status=[409],
                             extra_environ=self.extra_environ)
         # error message is wrong - ends up in package_create,
@@ -210,7 +207,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
             offset = self.relationship_offset('annakarenina', 'relationships', 'warandpeace')
             data = {'type': 'parent_of',
                     'comment':self.comment}
-        postparams = '%s=1' % self.dumps(data)
+        postparams = '{0!s}=1'.format(self.dumps(data))
         res = self.app.post(offset, params=postparams, status=[201],
                             extra_environ=self.extra_environ)
         # Check the response
@@ -228,7 +225,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
 
     def update_annakarenina_parent_of_war_and_peace(self, comment=u'New comment.'):
         offset = self.relationship_offset('annakarenina', 'parent_of', 'warandpeace')
-        postparams = '%s=1' % self.dumps({'comment':comment})
+        postparams = '{0!s}=1'.format(self.dumps({'comment':comment}))
         res = self.app.put(offset, params=postparams, status=[200], extra_environ=self.extra_environ)
         # Check the response
         rel = self.loads(res.body)
@@ -247,7 +244,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
     def test_update_relationship_incorrectly(self):
         self.create_annakarenina_parent_of_war_and_peace()
         offset = self.relationship_offset('annakarenina', 'parent_of', 'warandpeace')
-        postparams = '%s=1' % self.dumps({'type': 'cat', 'object': 'Matilda', 'comment': 'Tabby'})
+        postparams = '{0!s}=1'.format(self.dumps({'type': 'cat', 'object': 'Matilda', 'comment': 'Tabby'}))
         # Should only be able to change the comment.
         # Todo: validate this properly and return an error
         # Currently it just ignores the changed type and subject/object
@@ -285,12 +282,12 @@ class RelationshipsTestCase(BaseModelApiTestCase):
         len_relationships = len(relationships)
         len_expected_relationships = len(expected_relationships)
         if len_relationships != len_expected_relationships:
-            msg = 'Found %i relationships, ' % len_relationships
-            msg += 'but expected %i.' % len_expected_relationships
+            msg = 'Found {0:d} relationships, '.format(len_relationships)
+            msg += 'but expected {0:d}.'.format(len_expected_relationships)
             if len_relationships:
                 msg += ' Found: '
                 for r in relationships:
-                    msg += '%s %s %s; ' % (r['subject'], r['type'], r['object'])
+                    msg += '{0!s} {1!s} {2!s}; '.format(r['subject'], r['type'], r['object'])
                 msg += '.'
             raise Exception, msg
 
@@ -307,8 +304,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
                     the_expected_rel = expected_rel
                     break
             if not the_expected_rel:
-                raise Exception('Unexpected relationship: %s %s %s' %
-                                (rel['subject'], rel['type'], rel['object']))
+                raise Exception('Unexpected relationship: {0!s} {1!s} {2!s}'.format(rel['subject'], rel['type'], rel['object']))
             for field in ('subject', 'object', 'type', 'comment'):
                 if the_expected_rel.has_key(field):
                     value = rel[field]

--- a/ckan/tests/functional/api/model/test_vocabulary.py
+++ b/ckan/tests/functional/api/model/test_vocabulary.py
@@ -1043,7 +1043,7 @@ class TestVocabulary(object):
                 status=404)
         assert response.json['success'] is False
         msg = response.json['error']['message']
-        assert msg == u'Not found: Could not find tag "%s"' % 'nonexistent', \
+        assert msg == u'Not found: Could not find tag "{0!s}"'.format('nonexistent'), \
                 msg
 
     def test_delete_tag_vocab_not_exists(self):
@@ -1084,7 +1084,7 @@ class TestVocabulary(object):
                     status=404)
             assert response.json['success'] is False
             msg = response.json['error']['message']
-            assert msg == u'Not found: Could not find tag "%s"' % tag_name, msg
+            assert msg == u'Not found: Could not find tag "{0!s}"'.format(tag_name), msg
 
     def test_delete_tag_invalid_vocab(self):
         '''Test the error response when a user tries to delete a tag but gives
@@ -1103,8 +1103,7 @@ class TestVocabulary(object):
                     status=404)
             assert response.json['success'] is False
             msg = response.json['error']['message']
-            assert msg == u"Not found: could not find vocabulary '%s'" \
-                    % vocab_name, msg
+            assert msg == u"Not found: could not find vocabulary '{0!s}'".format(vocab_name), msg
 
     def test_delete_tag_not_logged_in(self):
         vocab = self.genre_vocab

--- a/ckan/tests/functional/api/test_activity.py
+++ b/ckan/tests/functional/api/test_activity.py
@@ -214,7 +214,7 @@ class TestActivity:
             extra_environ = {'Authorization': str(apikey)}
         else:
             extra_environ = None
-        response = self.app.get("/api/2/rest/user/%s/activity" % user_id,
+        response = self.app.get("/api/2/rest/user/{0!s}/activity".format(user_id),
                 extra_environ=extra_environ)
         return json.loads(response.body)
 
@@ -223,7 +223,7 @@ class TestActivity:
             extra_environ = {'Authorization': str(apikey)}
         else:
             extra_environ = None
-        response = self.app.get("/api/2/rest/dataset/%s/activity" % package_id,
+        response = self.app.get("/api/2/rest/dataset/{0!s}/activity".format(package_id),
                 extra_environ=extra_environ)
         return json.loads(response.body)
 
@@ -232,7 +232,7 @@ class TestActivity:
             extra_environ = {'Authorization': str(apikey)}
         else:
             extra_environ = None
-        response = self.app.get("/api/2/rest/group/%s/activity" % group_id,
+        response = self.app.get("/api/2/rest/group/{0!s}/activity".format(group_id),
                 extra_environ=extra_environ)
         return json.loads(response.body)
 
@@ -252,7 +252,7 @@ class TestActivity:
 
     def activity_details(self, activity):
         response = self.app.get(
-                "/api/2/rest/activity/%s/details" % activity['id'])
+                "/api/2/rest/activity/{0!s}/details".format(activity['id']))
         return json.loads(response.body)
 
     def record_details(self, user_id, package_id=None, group_ids=None,
@@ -497,7 +497,7 @@ class TestActivity:
                 apikey=apikey)
         extras_after = updated_package['extras']
         assert len(extras_after) == len(extras_before) - 1, (
-                "%s != %s" % (len(extras_after), len(extras_before) - 1))
+                "{0!s} != {1!s}".format(len(extras_after), len(extras_before) - 1))
 
         # Find the new activity in the user's activity stream.
         user_new_activities = (find_new_activities(
@@ -546,14 +546,13 @@ class TestActivity:
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
         assert len(details) == 1, (
-                "There should be 1 activity detail but found %s"
-                % len(details))
+                "There should be 1 activity detail but found {0!s}".format(len(details)))
         detail = details[0]
         assert detail['activity_id'] == activity['id'], \
             str(detail['activity_id'])
         deleted_extras = [extra for extra in extras_before if extra not in
                 extras_after]
-        assert len(deleted_extras) == 1, "%s != 1" % len(deleted_extras)
+        assert len(deleted_extras) == 1, "{0!s} != 1".format(len(deleted_extras))
         deleted_extra = deleted_extras[0]
         assert detail['object_type'] == "PackageExtra", (
             str(detail['object_type']))
@@ -591,7 +590,7 @@ class TestActivity:
                 apikey=apikey)
         extras_after = updated_package['extras']
         assert len(extras_after) == len(extras_before), (
-                "%s != %s" % (len(extras_after), len(extras_before)))
+                "{0!s} != {1!s}".format(len(extras_after), len(extras_before)))
 
         # Find the new activity in the user's activity stream.
         user_new_activities = (find_new_activities(
@@ -640,14 +639,13 @@ class TestActivity:
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
         assert len(details) == 1, (
-                "There should be 1 activity detail but found %s"
-                % len(details))
+                "There should be 1 activity detail but found {0!s}".format(len(details)))
         detail = details[0]
         assert detail['activity_id'] == activity['id'], \
             str(detail['activity_id'])
         new_extras = [extra for extra in extras_after if extra not in
                 extras_before]
-        assert len(new_extras) == 1, "%s != 1" % len(new_extras)
+        assert len(new_extras) == 1, "{0!s} != 1".format(len(new_extras))
         new_extra = new_extras[0]
         assert detail['object_type'] == "PackageExtra", (
             str(detail['object_type']))
@@ -683,7 +681,7 @@ class TestActivity:
                 apikey=apikey)
         extras_after = updated_package['extras']
         assert len(extras_after) == len(extras_before) + 1, (
-                "%s != %s" % (len(extras_after), len(extras_before) + 1))
+                "{0!s} != {1!s}".format(len(extras_after), len(extras_before) + 1))
 
         # Find the new activity in the user's activity stream.
         user_new_activities = (find_new_activities(
@@ -732,14 +730,13 @@ class TestActivity:
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
         assert len(details) == 1, (
-                "There should be 1 activity detail but found %s"
-                % len(details))
+                "There should be 1 activity detail but found {0!s}".format(len(details)))
         detail = details[0]
         assert detail['activity_id'] == activity['id'], \
             str(detail['activity_id'])
         new_extras = [extra for extra in extras_after if extra not in
                 extras_before]
-        assert len(new_extras) == 1, "%s != 1" % len(new_extras)
+        assert len(new_extras) == 1, "{0!s} != 1".format(len(new_extras))
         new_extra = new_extras[0]
         assert detail['object_type'] == "PackageExtra", (
             str(detail['object_type']))
@@ -950,8 +947,7 @@ class TestActivity:
         assert len(details) == num_resources
         for detail in details:
             assert detail['activity_id'] == activity['id'], (
-                "activity_id should be %s but is %s"
-                % (activity['id'], detail['activity_id']))
+                "activity_id should be {0!s} but is {1!s}".format(activity['id'], detail['activity_id']))
             assert detail['object_id'] in resource_ids, (
                 str(detail['object_id']))
             assert detail['object_type'] == "Resource", (

--- a/ckan/tests/functional/api/test_package_search.py
+++ b/ckan/tests/functional/api/test_package_search.py
@@ -69,7 +69,7 @@ class PackageSearchApiTestCase(ApiTestCase, ControllerTestCase):
         check_error(UnicodeMultiDict({'{"q": illegal json}': u'1'}))
 
     def test_01_uri_q(self):
-        offset = self.base_url + '?q=%s' % self.package_fixture_data['name']
+        offset = self.base_url + '?q={0!s}'.format(self.package_fixture_data['name'])
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, ['testpkg'])
@@ -86,7 +86,7 @@ class PackageSearchApiTestCase(ApiTestCase, ControllerTestCase):
     def test_03_uri_qjson(self):
         query = {'q': self.package_fixture_data['name']}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, ['testpkg'])
@@ -104,7 +104,7 @@ class PackageSearchApiTestCase(ApiTestCase, ControllerTestCase):
     def test_05_uri_json_tags(self):
         query = {'q': 'annakarenina tags:russian tags:tolstoy'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina'])
@@ -113,7 +113,7 @@ class PackageSearchApiTestCase(ApiTestCase, ControllerTestCase):
     def test_05_uri_json_tags_multiple(self):
         query = {'q': 'tags:russian tags:tolstoy'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina'])
@@ -121,7 +121,7 @@ class PackageSearchApiTestCase(ApiTestCase, ControllerTestCase):
 
     def test_06_uri_q_tags(self):
         query = webhelpers.util.html_escape('annakarenina tags:russian tags:tolstoy')
-        offset = self.base_url + '?q=%s' % query
+        offset = self.base_url + '?q={0!s}'.format(query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina'])
@@ -147,7 +147,7 @@ class PackageSearchApiTestCase(ApiTestCase, ControllerTestCase):
     def test_12_all_packages_qjson(self):
         query = {'q': ''}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         assert_equal(res_dict['count'], 3)
@@ -204,7 +204,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
     def test_07_uri_qjson_tags(self):
         query = {'q': '', 'tags':['tolstoy']}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina'])
@@ -213,7 +213,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
     def test_07_uri_qjson_tags_with_flexible_query(self):
         query = {'q': '', 'tags':['Flexible \u30a1']}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina', u'warandpeace'])
@@ -222,7 +222,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
     def test_07_uri_qjson_tags_multiple(self):
         query = {'q': '', 'tags':['tolstoy', 'russian', u'Flexible \u30a1']}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         print offset
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
@@ -232,7 +232,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
     def test_07_uri_qjson_tags_reverse(self):
         query = {'q': '', 'tags':['russian']}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina', u'warandpeace'])
@@ -246,7 +246,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
     
         query = {"geographic_coverage":"England"}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, ['testpkg'])
@@ -255,7 +255,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
     def test_07_uri_qjson_extras_2(self):
         query = {"national_statistic":"yes"}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, ['testpkg'])
@@ -270,7 +270,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
         
         query = {'q': 'russian', 'all_fields': 1}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         assert res_dict['count'] == 2, res_dict
@@ -305,14 +305,14 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
 
     def test_10_single_tag_with_plus(self):
         tagname = "Flexible+" + quote(u'\u30a1'.encode('utf8'))
-        offset = self.base_url + "?tags=%s&all_fields=1"%tagname
+        offset = self.base_url + "?tags={0!s}&all_fields=1".format(tagname)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         assert res_dict['count'] == 2, res_dict
 
     def test_10_multi_tags_with_ampersand_including_a_multiword_tagame(self):
         tagname = "Flexible+" + quote(u'\u30a1'.encode('utf8'))
-        offset = self.base_url + '?tags=tolstoy&tags=%s&all_fields=1' % tagname
+        offset = self.base_url + '?tags=tolstoy&tags={0!s}&all_fields=1'.format(tagname)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         assert res_dict['count'] == 1, res_dict
@@ -372,7 +372,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
     def test_07_uri_qjson_tags(self):
         query = {'q': 'tags:tolstoy'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina'])
@@ -381,7 +381,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
     def test_07_uri_qjson_tags_with_unicode(self):
         query = {'q': u'tags:"Flexible \u30a1"'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina', u'warandpeace'])
@@ -390,7 +390,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
     def test_07_uri_qjson_tags_multiple(self):
         query = {'q': 'tags:tolstoy tags:russian'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         print offset
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
@@ -400,7 +400,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
     def test_07_uri_qjson_tags_reverse(self):
         query = {'q': 'tags:russian'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina', u'warandpeace'])
@@ -409,7 +409,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
     def test_07_uri_qjson_extras_2(self):
         query = {'q': "national_statistic:yes"}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, ['testpkg'])
@@ -418,7 +418,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
     def test_08_all_fields(self):
         query = {'q': 'russian', 'fl': '*'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         assert res_dict['count'] == 2, res_dict

--- a/ckan/tests/functional/api/test_resource_search.py
+++ b/ckan/tests/functional/api/test_resource_search.py
@@ -53,7 +53,7 @@ class ResourceSearchApiTestCase(ApiTestCase, ControllerTestCase):
     def test_02_url_qjson(self):
         query = {'url':'site'}
         json_query = self.dumps(query)
-        offset = self.base_url + '?qjson=%s' % json_query
+        offset = self.base_url + '?qjson={0!s}'.format(json_query)
         self.assert_urls_in_search_results(offset, [self.ab, self.cd])
 
     def test_03_post_qjson(self):

--- a/ckan/tests/functional/api/test_revision_search.py
+++ b/ckan/tests/functional/api/test_revision_search.py
@@ -29,14 +29,14 @@ class RevisionSearchApiTestCase(ApiTestCase, ControllerTestCase):
         offset = self.offset('/search/revision')
         revs = model.Session.query(model.Revision).all()
         rev_first = revs[-1]
-        params = "?since_id=%s" % rev_first.id
+        params = "?since_id={0!s}".format(rev_first.id)
         res = self.app.get(offset+params, status=200)
         res_list = self.data_from_res(res)
         assert rev_first.id not in res_list
         for rev in revs[:-1]:
             assert rev.id in res_list, (rev.id, res_list)
         rev_last = revs[0]
-        params = "?since_id=%s" % rev_last.id
+        params = "?since_id={0!s}".format(rev_last.id)
         res = self.app.get(offset+params, status=200)
         res_list = self.data_from_res(res)
         assert res_list == [], res_list
@@ -46,7 +46,7 @@ class RevisionSearchApiTestCase(ApiTestCase, ControllerTestCase):
         revs = model.Session.query(model.Revision).all()
         # Check since time of first.
         rev_first = revs[-1]
-        params = "?since_time=%s" % rev_first.timestamp.isoformat()
+        params = "?since_time={0!s}".format(rev_first.timestamp.isoformat())
         res = self.app.get(offset+params, status=200)
         res_list = self.data_from_res(res)
         assert rev_first.id not in res_list
@@ -54,7 +54,7 @@ class RevisionSearchApiTestCase(ApiTestCase, ControllerTestCase):
             assert rev.id in res_list, (rev.id, res_list)
         # Check since time of last.
         rev_last = revs[0]
-        params = "?since_time=%s" % rev_last.timestamp.isoformat()
+        params = "?since_time={0!s}".format(rev_last.timestamp.isoformat())
         res = self.app.get(offset+params, status=200)
         res_list = self.data_from_res(res)
         assert res_list == [], res_list

--- a/ckan/tests/functional/test_activity.py
+++ b/ckan/tests/functional/test_activity.py
@@ -52,7 +52,7 @@ class TestActivity(HtmlCheckMethods):
         offset = url_for(controller='user', action='activity', id=user['id'])
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s signed up' % user['fullname'] in stripped, stripped
+        assert '{0!s} signed up'.format(user['fullname']) in stripped, stripped
 
         # Create a new package.
         package = {
@@ -69,7 +69,7 @@ class TestActivity(HtmlCheckMethods):
         package = package_create(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s created the dataset %s ' % (
+        assert '{0!s} created the dataset {1!s} '.format(
                 user['fullname'], package['title']) in stripped, stripped
 
         # Add a resource to the package.
@@ -87,8 +87,7 @@ class TestActivity(HtmlCheckMethods):
         package = package_update(context, request_data)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s added the resource %s to the dataset %s' % \
-                (user['fullname'], resource['name'], package['title']) \
+        assert '{0!s} added the resource {1!s} to the dataset {2!s}'.format(user['fullname'], resource['name'], package['title']) \
                 in stripped, stripped
 
         # Update the package.
@@ -96,8 +95,7 @@ class TestActivity(HtmlCheckMethods):
         package = package_update(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s updated the dataset %s' \
-                % (user['fullname'], package['title']) \
+        assert '{0!s} updated the dataset {1!s}'.format(user['fullname'], package['title']) \
                 in stripped, stripped
 
         # Update the resource.
@@ -106,8 +104,7 @@ class TestActivity(HtmlCheckMethods):
         resource = resource_update(context, resource)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s updated the resource %s in the dataset %s' \
-                % (user['fullname'], resource['name'], package['title']) \
+        assert '{0!s} updated the resource {1!s} in the dataset {2!s}'.format(user['fullname'], resource['name'], package['title']) \
                 in stripped, stripped
 
         # Delete the resource.
@@ -116,22 +113,21 @@ class TestActivity(HtmlCheckMethods):
         package_update(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s deleted the resource %s from the dataset %s' % \
-                (user['fullname'], resource['name'], package['title']) \
+        assert '{0!s} deleted the resource {1!s} from the dataset {2!s}'.format(user['fullname'], resource['name'], package['title']) \
                 in stripped, stripped
 
         # Follow the package.
         follow_dataset(context, {'id': package['id']})
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s started following %s' % (user['fullname'],
+        assert '{0!s} started following {1!s}'.format(user['fullname'],
                 package['title']) not in stripped, stripped
 
         # Follow another user.
         follow_user(context, {'id': 'joeadmin'})
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s started following %s' % (user['fullname'],
+        assert '{0!s} started following {1!s}'.format(user['fullname'],
                 'joeadmin') not in stripped, stripped
 
         # Create a new group.
@@ -143,7 +139,7 @@ class TestActivity(HtmlCheckMethods):
         group = group_create(context, group)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s created the group %s' % (user['fullname'], group['title']) \
+        assert '{0!s} created the group {1!s}'.format(user['fullname'], group['title']) \
                 in stripped, stripped
 
         # Update the group.
@@ -151,7 +147,7 @@ class TestActivity(HtmlCheckMethods):
         group = group_update(context, group)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s updated the group %s' % (user['fullname'], group['title']) \
+        assert '{0!s} updated the group {1!s}'.format(user['fullname'], group['title']) \
                 in stripped, stripped
 
         # Delete the group.
@@ -159,7 +155,7 @@ class TestActivity(HtmlCheckMethods):
         group_update(context, group)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s deleted the group %s' % (user['fullname'], group['title']) \
+        assert '{0!s} deleted the group {1!s}'.format(user['fullname'], group['title']) \
                 in stripped, stripped
 
         # Add a new tag to the package.
@@ -168,8 +164,7 @@ class TestActivity(HtmlCheckMethods):
         package = package_update(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s added the tag %s to the dataset %s' % \
-                (user['fullname'], tag['name'], package['title']) \
+        assert '{0!s} added the tag {1!s} to the dataset {2!s}'.format(user['fullname'], tag['name'], package['title']) \
                 in stripped, stripped
 
         # Remove the tag from the package.
@@ -178,8 +173,7 @@ class TestActivity(HtmlCheckMethods):
         package_update(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s removed the tag %s from the dataset %s' % \
-                (user['fullname'], tag['name'], package['title']) \
+        assert '{0!s} removed the tag {1!s} from the dataset {2!s}'.format(user['fullname'], tag['name'], package['title']) \
                 in stripped, stripped
 
         # Add an extra to the package.
@@ -187,8 +181,7 @@ class TestActivity(HtmlCheckMethods):
         package = package_update(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s added the extra "%s" to the dataset %s' % \
-                (user['fullname'], 'quality', package['title']) \
+        assert '{0!s} added the extra "{1!s}" to the dataset {2!s}'.format(user['fullname'], 'quality', package['title']) \
                 in stripped, stripped
 
         # Update the extra.
@@ -196,8 +189,7 @@ class TestActivity(HtmlCheckMethods):
         package = package_update(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s changed the extra "%s" of the dataset %s' % \
-                (user['fullname'], 'quality', package['title']) \
+        assert '{0!s} changed the extra "{1!s}" of the dataset {2!s}'.format(user['fullname'], 'quality', package['title']) \
                 in stripped, stripped
 
         # Delete the extra.
@@ -205,8 +197,7 @@ class TestActivity(HtmlCheckMethods):
         package = package_update(context, package)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s deleted the extra "%s" from the dataset %s' % \
-                (user['fullname'], 'quality', package['title']) \
+        assert '{0!s} deleted the extra "{1!s}" from the dataset {2!s}'.format(user['fullname'], 'quality', package['title']) \
                 in stripped, stripped
 
         # Delete the package.
@@ -216,8 +207,7 @@ class TestActivity(HtmlCheckMethods):
         del context['ignore_auth']
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s deleted the dataset %s' % \
-                (user['fullname'], package['title']) \
+        assert '{0!s} deleted the dataset {1!s}'.format(user['fullname'], package['title']) \
                 in stripped, stripped
 
         # Update the user's profile.
@@ -225,7 +215,7 @@ class TestActivity(HtmlCheckMethods):
         user_update(context, user)
         result = self.app.get(offset, status=200)
         stripped = self.strip_tags(result)
-        assert '%s updated their profile' % user['fullname'] \
+        assert '{0!s} updated their profile'.format(user['fullname']) \
                 in stripped, stripped
 
         # By now we've created >15 activities, but only the latest 15 should

--- a/ckan/tests/functional/test_admin.py
+++ b/ckan/tests/functional/test_admin.py
@@ -59,17 +59,17 @@ class _TestAdminAuthzController(WsgiAppCase):
 
 
         def check_and_set_checkbox(theform, user, role, should_be, set_to):
-           user_role_string = '%s$%s' % (user, role)
+           user_role_string = '{0!s}${1!s}'.format(user, role)
            checkboxes = [x for x in theform.fields[user_role_string] \
                                            if x.__class__.__name__ == 'Checkbox']
 
            assert(len(checkboxes)==1), \
-                "there should only be one checkbox for %s/%s" % (user, role)
+                "there should only be one checkbox for {0!s}/{1!s}".format(user, role)
            checkbox = checkboxes[0]
 
            #checkbox should be unticked
            assert checkbox.checked==should_be, \
-                         "%s/%s checkbox in unexpected state" % (user, role)
+                         "{0!s}/{1!s} checkbox in unexpected state".format(user, role)
 
            #tick or untick the box and submit the form
            checkbox.checked=set_to

--- a/ckan/tests/functional/test_group.py
+++ b/ckan/tests/functional/test_group.py
@@ -209,7 +209,7 @@ class TestRevisions(FunctionalTestCase):
     def test_2_atom_feed(self):
         offset = url_for(controller='group', action='history',
                          id=self.grp.name)
-        offset = "%s?format=atom" % offset
+        offset = "{0!s}?format=atom".format(offset)
         res = self.app.get(offset)
         assert '<feed' in res, res
         assert 'xmlns="http://www.w3.org/2005/Atom"' in res, res

--- a/ckan/tests/functional/test_package.py
+++ b/ckan/tests/functional/test_package.py
@@ -44,15 +44,15 @@ class TestPackageForm(TestPackageBase):
     '''Inherit this in tests for these form testing methods'''
     def _check_package_read(self, res, **params):
         assert not 'Error' in res, res
-        assert u'%s - Datasets' % params['title'] in res, res
+        assert u'{0!s} - Datasets'.format(params['title']) in res, res
         main_res = self.main_div(res)
         main_div = main_res
         main_div_str = main_div.encode('utf8')
         assert params['name'] in main_div, main_div_str
         assert params['title'] in main_div, main_div_str
         assert params['version'] in main_div, main_div_str
-        self.check_named_element(main_div, 'a', 'href="%s"' % params['url'])
-        prefix = 'Dataset-%s-' % params.get('id', '')
+        self.check_named_element(main_div, 'a', 'href="{0!s}"'.format(params['url']))
+        prefix = 'Dataset-{0!s}-'.format(params.get('id', ''))
         for res_index, values in self._get_resource_values(params['resources'], by_resource=True):
             self.check_named_element(main_div, 'tr', *values)
         assert params['notes'] in main_div, main_div_str
@@ -61,7 +61,7 @@ class TestPackageForm(TestPackageBase):
         tag_names = list(params['tags'])
         self.check_named_element(main_div, 'ul', *tag_names)
         if params.has_key('state'):
-            assert 'State: %s' % params['state'] in main_div.replace('</strong>', ''), main_div_str
+            assert 'State: {0!s}'.format(params['state']) in main_div.replace('</strong>', ''), main_div_str
         if isinstance(params['extras'], dict):
             extras = []
             for key, value in params['extras'].items():
@@ -145,10 +145,10 @@ class TestPackageForm(TestPackageBase):
             value_in_html_body = self.escape_for_html_body(value)
             key_escaped = genshi_escape(key)
             value_escaped = genshi_escape(value)
-            self.check_tag(main_res, 'extras__%s__key' % num, key_in_html_body)
-            self.check_tag(main_res, 'extras__%s__value' % num, value_escaped)
+            self.check_tag(main_res, 'extras__{0!s}__key'.format(num), key_in_html_body)
+            self.check_tag(main_res, 'extras__{0!s}__value'.format(num), value_escaped)
             if deleted:
-                self.check_tag(main_res, 'extras__%s__deleted' % num, 'checked')
+                self.check_tag(main_res, 'extras__{0!s}__deleted'.format(num), 'checked')
 
         assert params['log_message'] in main_res, main_res
 
@@ -187,8 +187,7 @@ class TestPackageForm(TestPackageBase):
             redirected_to = dict(res.headers).get('Location') or dict(res.headers)['location']
             expected_redirect_url = expected_redirect.replace('<NAME>', new_name)
             assert redirected_to == expected_redirect_url, \
-                   'Redirected to %s but should have been %s' % \
-                   (redirected_to, expected_redirect_url)
+                   'Redirected to {0!s} but should have been {1!s}'.format(redirected_to, expected_redirect_url)
         finally:
             # revert name change or pkg creation
             pkg = model.Package.by_name(new_name)
@@ -229,8 +228,8 @@ class TestReadOnly(TestPackageForm, HtmlCheckMethods, PylonsTestCase):
         res = self.app.get(offset)
         def check_link(res, controller, id):
             id_in_uri = id.strip('"').replace(' ', '%20') # remove quotes and percent-encode spaces
-            self.check_tag_and_data(res, 'a ', '%s/%s' % (controller, id_in_uri),
-                                    '%s:%s' % (controller, id.replace('"', '&#34;')))
+            self.check_tag_and_data(res, 'a ', '{0!s}/{1!s}'.format(controller, id_in_uri),
+                                    '{0!s}:{1!s}'.format(controller, id.replace('"', '&#34;')))
         check_link(res, 'dataset', 'pkg-1')
         check_link(res, 'tag', 'tag_1')
         check_link(res, 'tag', '"multi word with punctuation."')
@@ -330,13 +329,13 @@ class TestReadAtRevision(FunctionalTestCase, HtmlCheckMethods):
                            status=400)
 
     def test_read_revision1(self):
-        offset = self.offset + '@%s' % self.revision_ids[0]
+        offset = self.offset + '@{0!s}'.format(self.revision_ids[0])
         res = self.app.get(offset, status=200)
         main_html = pkg_html = side_html = res.body
         print 'MAIN', main_html
         assert 'This is an old revision of this dataset' in main_html
         assert 'at January 1, 2011, 00:00' in main_html
-        self.check_named_element(main_html, 'a', 'href="/dataset/%s"' % self.pkg_name)
+        self.check_named_element(main_html, 'a', 'href="/dataset/{0!s}"'.format(self.pkg_name))
         print 'PKG', pkg_html
         assert 'title1' in res
         assert 'key2' not in pkg_html
@@ -346,13 +345,13 @@ class TestReadAtRevision(FunctionalTestCase, HtmlCheckMethods):
         assert 'tag 2' not in side_html
 
     def test_read_revision2(self):
-        offset = self.offset + '@%s' % self.revision_ids[1]
+        offset = self.offset + '@{0!s}'.format(self.revision_ids[1])
         res = self.app.get(offset, status=200)
         main_html = pkg_html = side_html = res.body
         print 'MAIN', main_html
         assert 'This is an old revision of this dataset' in main_html
         assert 'at January 2, 2011, 00:00' in main_html
-        self.check_named_element(main_html, 'a', 'href="/dataset/%s"' % self.pkg_name)
+        self.check_named_element(main_html, 'a', 'href="/dataset/{0!s}"'.format(self.pkg_name))
         print 'PKG', pkg_html
         assert 'title2' in res
         assert 'key2' in pkg_html
@@ -362,7 +361,7 @@ class TestReadAtRevision(FunctionalTestCase, HtmlCheckMethods):
         assert 'tag 2' in side_html
 
     def test_read_revision3(self):
-        offset = self.offset + '@%s' % self.revision_ids[2]
+        offset = self.offset + '@{0!s}'.format(self.revision_ids[2])
         res = self.app.get(offset, status=200)
         main_html = pkg_html = side_html = res.body
         print 'MAIN', main_html
@@ -370,7 +369,7 @@ class TestReadAtRevision(FunctionalTestCase, HtmlCheckMethods):
         # It is not an old revision, but working that out is hard. The request
         # was for a particular revision, so assume it is old.
         assert 'at January 3, 2011, 00:00' in main_html
-        self.check_named_element(main_html, 'a', 'href="/dataset/%s"' % self.pkg_name)
+        self.check_named_element(main_html, 'a', 'href="/dataset/{0!s}"'.format(self.pkg_name))
         print 'PKG', pkg_html
         assert 'title3' in res
         assert 'key2' in pkg_html
@@ -431,7 +430,7 @@ class TestEdit(TestPackageForm):
 
     def test_edit_2_not_groups(self):
         # not allowed to edit groups for now
-        prefix = 'Dataset-%s-' % self.pkgid
+        prefix = 'Dataset-{0!s}-'.format(self.pkgid)
         fv = self.res.forms['dataset-edit']
         assert not fv.fields.has_key(prefix + 'groups')
 
@@ -749,7 +748,7 @@ class TestRevisions(TestPackageBase):
         model.repo.rebuild_db()
 
     def test_2_atom_feed(self):
-        offset = "%s?format=atom" % self.offset
+        offset = "{0!s}?format=atom".format(self.offset)
         res = self.app.get(offset)
         assert '<feed' in res, res
         assert 'xmlns="http://www.w3.org/2005/Atom"' in res, res

--- a/ckan/tests/functional/test_pagination.py
+++ b/ckan/tests/functional/test_pagination.py
@@ -9,11 +9,11 @@ from ckan.tests import TestController, url_for, setup_test_search_index
 def scrape_search_results(response, object_type):
     assert object_type in ('dataset', 'group_dataset', 'group', 'user')
     if object_type is not 'group_dataset':
-        results = re.findall('href="/%s/%s_(\d\d)"' % (object_type, object_type),
+        results = re.findall('href="/{0!s}/{1!s}_(\d\d)"'.format(object_type, object_type),
                              str(response))
     else:
         object_type = 'dataset'
-        results = re.findall('href="/%s/%s_(\d\d)"' % (object_type, object_type),
+        results = re.findall('href="/{0!s}/{1!s}_(\d\d)"'.format(object_type, object_type),
                              str(response))
     return results
 
@@ -46,7 +46,7 @@ class TestPaginationPackage(TestController):
         for i in range(cls.num_packages_in_large_group):
             packages.append({
                 # CS: nasty_string ignore
-                'name': u'dataset_%s' % str(i).zfill(2),
+                'name': u'dataset_{0!s}'.format(str(i).zfill(2)),
                 'groups': u'group_00'
             })
 
@@ -88,7 +88,7 @@ class TestPaginationGroup(TestController):
         cls.num_groups = 22
 
         # CS: nasty_string ignore
-        groups = [u'group_%s' % str(i).zfill(2) for i in range(0, cls.num_groups)]
+        groups = [u'group_{0!s}'.format(str(i).zfill(2)) for i in range(0, cls.num_groups)]
 
         CreateTestData.create_arbitrary(
             [], extra_group_names=groups
@@ -121,7 +121,7 @@ class TestPaginationUsers(TestController):
         cls.num_users = 21
 
         # CS: nasty_string ignore
-        users = [u'user_%s' % str(i).zfill(2) for i in range(cls.num_users)]
+        users = [u'user_{0!s}'.format(str(i).zfill(2)) for i in range(cls.num_users)]
 
         CreateTestData.create_arbitrary(
             [], extra_user_names = users,

--- a/ckan/tests/functional/test_related.py
+++ b/ckan/tests/functional/test_related.py
@@ -447,7 +447,7 @@ class TestRelatedActionAPI(apibase.BaseModelApiTestCase):
             "type": rtype,
             "title": title
         }
-        postparams = '%s=1' % json.dumps(r)
+        postparams = '{0!s}=1'.format(json.dumps(r))
         res = self.app.post("/api/3/action/related_create", params=postparams,
                             status=self.STATUS_200_OK,
                             extra_environ=self.extra_environ)
@@ -466,7 +466,7 @@ class TestRelatedActionAPI(apibase.BaseModelApiTestCase):
         r = {
             "id": existing["result"]["id"]
         }
-        postparams = '%s=1' % json.dumps(r)
+        postparams = '{0!s}=1'.format(json.dumps(r))
         res = self.app.post("/api/3/action/related_show", params=postparams,
                             status=self.STATUS_200_OK,
                             extra_environ=self.extra_environ)
@@ -487,7 +487,7 @@ class TestRelatedActionAPI(apibase.BaseModelApiTestCase):
         r = {
             "id": p.id
         }
-        postparams = '%s=1' % json.dumps(r)
+        postparams = '{0!s}=1'.format(json.dumps(r))
         res = self.app.post("/api/3/action/related_list", params=postparams,
                             status=self.STATUS_200_OK,
                             extra_environ=self.extra_environ)
@@ -507,7 +507,7 @@ class TestRelatedActionAPI(apibase.BaseModelApiTestCase):
         r = {
             "id": existing["result"]["id"]
         }
-        postparams = '%s=1' % json.dumps(r)
+        postparams = '{0!s}=1'.format(json.dumps(r))
         res = self.app.post("/api/3/action/related_delete", params=postparams,
                             status=self.STATUS_200_OK,
                             extra_environ=self.extra_environ)
@@ -524,7 +524,7 @@ class TestRelatedActionAPI(apibase.BaseModelApiTestCase):
         usr = model.User.by_name("annafan")
         extra={'Authorization' : str(usr.apikey)}
 
-        postparams = '%s=1' % json.dumps(r)
+        postparams = '{0!s}=1'.format(json.dumps(r))
         res = self.app.post("/api/3/action/related_delete", params=postparams,
                             status=self.STATUS_403_ACCESS_DENIED,
                             extra_environ=extra)

--- a/ckan/tests/functional/test_revision.py
+++ b/ckan/tests/functional/test_revision.py
@@ -19,7 +19,7 @@ class TestRevisionController(TestController):
     def create_40_revisions(self):
         for i in range(0,40):
             rev = model.repo.new_revision()
-            rev.author = "Test Revision %s" % i
+            rev.author = "Test Revision {0!s}".format(i)
             model.repo.commit()
 
     def assert_click(self, res, link_exp, res2_exp):
@@ -88,10 +88,10 @@ class TestRevisionController(TestController):
     def test_read(self):
         anna = model.Package.by_name(u'annakarenina')
         rev_id = anna.revision.id
-        offset = url_for(controller='revision', action='read', id='%s' % rev_id)
+        offset = url_for(controller='revision', action='read', id='{0!s}'.format(rev_id))
         res = self.app.get(offset)
-        assert 'Revision %s' % rev_id in res
-        assert 'Revision: %s' % rev_id in res
+        assert 'Revision {0!s}'.format(rev_id) in res
+        assert 'Revision: {0!s}'.format(rev_id) in res
         # Todo: Reinstate asserts below, failing on 'Test Revision Deleting'
         #assert 'Author:</strong> tester' in res
         #assert 'Log Message:' in res

--- a/ckan/tests/functional/test_user.py
+++ b/ckan/tests/functional/test_user.py
@@ -18,7 +18,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
         if smtp_server:
             host, port = smtp_server.split(':')
             port = int(port) + int(str(hashlib.md5(cls.__name__).hexdigest())[0], 16)
-            config['smtp.test_server'] = '%s:%s' % (host, port)
+            config['smtp.test_server'] = '{0!s}:{1!s}'.format(host, port)
 
         PylonsTestCase.setup_class()
         SmtpServerHarness.setup_class()
@@ -28,7 +28,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
         for i in range(3):
             rev = model.repo.new_revision()
             pkg = model.Package.by_name(u'annakarenina')
-            pkg.notes = u'Changed notes %i' % i
+            pkg.notes = u'Changed notes {0:d}'.format(i)
             rev.author = u'annafan'
             model.repo.commit_and_remove()
 

--- a/ckan/tests/html_check.py
+++ b/ckan/tests/html_check.py
@@ -11,10 +11,10 @@ class HtmlCheckMethods(object):
     def named_div(self, div_name, html):
         'strips html to just the <div id="DIV_NAME"> section'
         the_html = self._get_html_from_res(html)
-        start_div = the_html.find(u'<div id="%s"' % div_name)
-        end_div = the_html.find(u'<!-- #%s -->' % div_name)
+        start_div = the_html.find(u'<div id="{0!s}"'.format(div_name))
+        end_div = the_html.find(u'<!-- #{0!s} -->'.format(div_name))
         if end_div == -1:
-            end_div = the_html.find(u'<!-- /%s -->' % div_name)
+            end_div = the_html.find(u'<!-- /{0!s} -->'.format(div_name))
         div_html = the_html[start_div:end_div]
         assert div_html
         return div_html
@@ -37,7 +37,7 @@ class HtmlCheckMethods(object):
         '''Searches in the html and returns True if it can find a particular
         tag and all its subtags & data which contains all the of the
         html_to_find'''
-        named_element_re = re.compile('(<(%(tag)s\w*).*?(>.*?</%(tag)s)?>)' % {'tag':tag_name}) 
+        named_element_re = re.compile('(<({tag!s}\w*).*?(>.*?</{tag!s})?>)'.format(**{'tag':tag_name})) 
         html_str = self._get_html_from_res(html)
         self._check_html(named_element_re, html_str.replace('\n', ''), html_to_find)
 
@@ -88,9 +88,9 @@ class HtmlCheckMethods(object):
                 return # found it
         # didn't find it
         if partly_matching_tags:
-            assert 0, "Couldn't find %s in html. Closest matches were:\n%s" % (', '.join(["'%s'" % html.encode('utf8') for html in html_to_find]), '\n'.join([tag.encode('utf8') for tag in partly_matching_tags]))
+            assert 0, "Couldn't find {0!s} in html. Closest matches were:\n{1!s}".format(', '.join(["'{0!s}'".format(html.encode('utf8')) for html in html_to_find]), '\n'.join([tag.encode('utf8') for tag in partly_matching_tags]))
         else:
-            assert 0, "Couldn't find %s in html. Tags matched were:\n%s" % (', '.join(["'%s'" % html.encode('utf8') for html in html_to_find]), '\n'.join([tag.group() for tag in regex_compiled.finditer(html_str)]))
+            assert 0, "Couldn't find {0!s} in html. Tags matched were:\n{1!s}".format(', '.join(["'{0!s}'".format(html.encode('utf8')) for html in html_to_find]), '\n'.join([tag.group() for tag in regex_compiled.finditer(html_str)]))
 
 
 

--- a/ckan/tests/lib/__init__.py
+++ b/ckan/tests/lib/__init__.py
@@ -12,4 +12,4 @@ def check_search_results(terms, expected_count, expected_packages=[]):
     count = result['count']
     assert_equal(count, expected_count)
     for expected_pkg in expected_packages:
-        assert expected_pkg in pkgs, '%s : %s' % (expected_pkg, result)
+        assert expected_pkg in pkgs, '{0!s} : {1!s}'.format(expected_pkg, result)

--- a/ckan/tests/lib/test_alphabet_pagination.py
+++ b/ckan/tests/lib/test_alphabet_pagination.py
@@ -18,10 +18,10 @@ class TestPages:
         pkgs = []
         for letter in 'abcd12':
             for i in range(0, 10):
-                name = u'testpackage_%s_%s' % (letter, i)
+                name = u'testpackage_{0!s}_{1!s}'.format(letter, i)
                 pkgs.append({
-                    'name': u'testpackage_%s_%s' % (letter, i),
-                    'title': u'%s Testpackage %s' % (letter, i),
+                    'name': u'testpackage_{0!s}_{1!s}'.format(letter, i),
+                    'title': u'{0!s} Testpackage {1!s}'.format(letter, i),
                     })
         cls.num_pkgs = len(pkgs)
         CreateTestData.create_arbitrary(pkgs)
@@ -102,10 +102,10 @@ class TestTooFewToPage:
         pkgs = []
         for letter in 'abcd12':
             for i in range(0, 1):
-                name = u'testpackage_%s_%s' % (letter, i)
+                name = u'testpackage_{0!s}_{1!s}'.format(letter, i)
                 pkgs.append({
-                    'name': u'testpackage_%s_%s' % (letter, i),
-                    'title': u'%s Testpackage %s' % (letter, i),
+                    'name': u'testpackage_{0!s}_{1!s}'.format(letter, i),
+                    'title': u'{0!s} Testpackage {1!s}'.format(letter, i),
                     })
         cls.num_pkgs = len(pkgs)
         CreateTestData.create_arbitrary(pkgs)

--- a/ckan/tests/lib/test_cli.py
+++ b/ckan/tests/lib/test_cli.py
@@ -27,7 +27,7 @@ class TestDb:
 
     def test_simple_dump_csv(self):
         csv_filepath = '/tmp/dump.tmp'
-        self.db.args = ('simple-dump-csv %s' % csv_filepath).split()
+        self.db.args = ('simple-dump-csv {0!s}'.format(csv_filepath)).split()
         self.db.simple_dump_csv()
         assert os.path.exists(csv_filepath), csv_filepath
         f_obj = open(csv_filepath, "r")
@@ -40,7 +40,7 @@ class TestDb:
 
     def test_simple_dump_json(self):
         json_filepath = '/tmp/dump.tmp'
-        self.db.args = ('simple-dump-json %s' % json_filepath).split()
+        self.db.args = ('simple-dump-json {0!s}'.format(json_filepath)).split()
         self.db.simple_dump_json()
         assert os.path.exists(json_filepath), json_filepath
         f_obj = open(json_filepath, "r")

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -93,7 +93,7 @@ class TestHelpers(TestController):
         email = 'zephod@gmail.com'
         default = config.get('ckan.gravatar_default', 'identicon')
         expected = ['<a href="https://gravatar.com/"',
-                   '<img src="//gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=%s"' % default,
+                   '<img src="//gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d={0!s}"'.format(default),
                    '</a>']
         # Hash the email address
         import hashlib

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -17,7 +17,7 @@ class TestMailer(SmtpServerHarness, PylonsTestCase):
         if smtp_server:
             host, port = smtp_server.split(':')
             port = int(port) + int(str(hashlib.md5(cls.__name__).hexdigest())[0], 16)
-            config['smtp.test_server'] = '%s:%s' % (host, port)
+            config['smtp.test_server'] = '{0!s}:{1!s}'.format(host, port)
         CreateTestData.create_user(name='bob', email='bob@bob.net')
         CreateTestData.create_user(name='mary') #NB No email addr provided
         SmtpServerHarness.setup_class()
@@ -61,7 +61,7 @@ class TestMailer(SmtpServerHarness, PylonsTestCase):
         assert test_email['subject'] in msg[3], msg[3]
         expected_body = self.mime_encode(test_email['body'],
                                          test_email['recipient_name'])
-        assert expected_body in msg[3], '%r not in %r' % (expected_body, msg[3])
+        assert expected_body in msg[3], '{0!r} not in {1!r}'.format(expected_body, msg[3])
 
     def test_mail_user(self):
         msgs = self.get_smtp_messages()
@@ -85,7 +85,7 @@ class TestMailer(SmtpServerHarness, PylonsTestCase):
         assert test_email['subject'] in msg[3], msg[3]
         expected_body = self.mime_encode(test_email['body'],
                                          'bob')
-        assert expected_body in msg[3], '%r not in %r' % (expected_body, msg[3])
+        assert expected_body in msg[3], '{0!r} not in {1!r}'.format(expected_body, msg[3])
 
     def test_mail_user_without_email(self):
         # send email
@@ -109,7 +109,7 @@ class TestMailer(SmtpServerHarness, PylonsTestCase):
         test_msg = mailer.get_reset_link_body(model.User.by_name(u'bob'))
         expected_body = self.mime_encode(test_msg,
                                          u'bob')
-        assert expected_body in msg[3], '%r not in %r' % (expected_body, msg[3])
+        assert expected_body in msg[3], '{0!r} not in {1!r}'.format(expected_body, msg[3])
 
         # reset link tested in user functional test
 
@@ -128,7 +128,7 @@ class TestMailer(SmtpServerHarness, PylonsTestCase):
         test_msg = mailer.get_invite_body(model.User.by_name(u'bob'))
         expected_body = self.mime_encode(test_msg,
                                          u'bob') 
-        assert expected_body in msg[3], '%r not in %r' % (expected_body, msg[3])
+        assert expected_body in msg[3], '{0!r} not in {1!r}'.format(expected_body, msg[3])
         assert user.reset_key is not None, user
         
         # reset link tested in user functional test

--- a/ckan/tests/lib/test_resource_search.py
+++ b/ckan/tests/lib/test_resource_search.py
@@ -149,7 +149,7 @@ class TestSearch(object):
         count = result['count']
         assert len(resources) == 2, resources
         assert count == all_resource_count, (count, all_resource_count)
-        assert resources == all_resources[:2], '%r, %r' % (resources, all_resources)
+        assert resources == all_resources[:2], '{0!r}, {1!r}'.format(resources, all_resources)
 
         # offset
         options = search.QueryOptions(order_by='id')

--- a/ckan/tests/lib/test_solr_package_search.py
+++ b/ckan/tests/lib/test_solr_package_search.py
@@ -375,7 +375,7 @@ class TestGeographicCoverage(TestController):
 
     def _filtered_search(self, value, expected_pkgs, count=None):
         query = {
-            'q': 'geographic_coverage:%s' % value,
+            'q': 'geographic_coverage:{0!s}'.format(value),
             'sort': 'rank'
         }
         result = search.query_for(model.Package).run(query)
@@ -425,7 +425,7 @@ class TestExtraFields(TestController):
         search.clear()
 
     def _do_search(self, department, expected_pkgs, count=None):
-        result = search.query_for(model.Package).run({'q': 'department: %s' % department})
+        result = search.query_for(model.Package).run({'q': 'department: {0!s}'.format(department)})
         pkgs = result['results']
         fields = [model.Package.by_name(pkg_name).name for pkg_name in pkgs]
         if not (count is None):
@@ -476,7 +476,7 @@ class TestRank(TestController):
         }
         result = search.query_for(model.Package).run(query)
         results = result['results']
-        err = 'Wanted %r, got %r' % (wanted_results, results)
+        err = 'Wanted {0!r}, got {1!r}'.format(wanted_results, results)
         assert wanted_results[0] == results[0], err
         assert wanted_results[1] == results[1], err
 

--- a/ckan/tests/lib/test_solr_search_index.py
+++ b/ckan/tests/lib/test_solr_search_index.py
@@ -24,9 +24,9 @@ class TestSolrConfig(TestController):
             conn.close()
         except socket.error, e:
             if not config.get('solr_url'):
-                raise AssertionError("Config option 'solr_url' needs to be defined in this CKAN's development.ini. Default of %s didn't work: %s" % (search.DEFAULT_SOLR_URL, e))
+                raise AssertionError("Config option 'solr_url' needs to be defined in this CKAN's development.ini. Default of {0!s} didn't work: {1!s}".format(search.DEFAULT_SOLR_URL, e))
             else:
-                raise AssertionError('SOLR connection problem. Connection defined in development.ini as: solr_url=%s Error: %s' % (config['solr_url'], e))
+                raise AssertionError('SOLR connection problem. Connection defined in development.ini as: solr_url={0!s} Error: {1!s}'.format(config['solr_url'], e))
 
 
 class TestSolrSearch:
@@ -35,7 +35,7 @@ class TestSolrSearch:
         setup_test_search_index()
         CreateTestData.create_search_test_data()
         cls.solr = search.make_connection()
-        cls.fq = " +site_id:\"%s\" " % config['ckan.site_id']
+        cls.fq = " +site_id:\"{0!s}\" ".format(config['ckan.site_id'])
         search.rebuild()
 
     @classmethod

--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -57,7 +57,7 @@ class TestAction(WsgiAppCase):
         }
         package.update(kwargs)
 
-        postparams = '%s=1' % json.dumps(package)
+        postparams = '{0!s}=1'.format(json.dumps(package))
         res = self.app.post('/api/action/package_create', params=postparams,
                             extra_environ={'Authorization': 'tester'})
         return json.loads(res.body)['result']
@@ -71,7 +71,7 @@ class TestAction(WsgiAppCase):
         assert 'annakarenina' in res['result']
         assert "/api/3/action/help_show?name=package_list" in res['help']
 
-        postparams = '%s=1' % json.dumps({'limit': 1})
+        postparams = '{0!s}=1'.format(json.dumps({'limit': 1}))
         res = json.loads(self.app.post('/api/action/package_list',
                          params=postparams).body)
         assert res['success'] is True
@@ -116,7 +116,7 @@ class TestAction(WsgiAppCase):
 
     def test_01_package_show_with_jsonp(self):
         anna_id = model.Package.by_name(u'annakarenina').id
-        postparams = '%s=1' % json.dumps({'id': anna_id})
+        postparams = '{0!s}=1'.format(json.dumps({'id': anna_id}))
         res = self.app.post('/api/action/package_show?callback=jsoncallback', params=postparams)
 
         assert re.match('jsoncallback\(.*\);', res.body), res
@@ -131,7 +131,7 @@ class TestAction(WsgiAppCase):
         assert not missing_keys, missing_keys
 
     def test_02_package_autocomplete_match_name(self):
-        postparams = '%s=1' % json.dumps({'q':'war', 'limit': 5})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'war', 'limit': 5}))
         res = self.app.post('/api/action/package_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert_equal(res_obj['success'], True)
@@ -142,7 +142,7 @@ class TestAction(WsgiAppCase):
         assert_equal(res_obj['result'][0]['match_displayed'], 'warandpeace')
 
     def test_02_package_autocomplete_match_title(self):
-        postparams = '%s=1' % json.dumps({'q':'a%20w', 'limit': 5})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'a%20w', 'limit': 5}))
         res = self.app.post('/api/action/package_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert_equal(res_obj['success'], True)
@@ -184,13 +184,13 @@ class TestAction(WsgiAppCase):
         }
 
         wee = json.dumps(package)
-        postparams = '%s=1' % json.dumps(package)
+        postparams = '{0!s}=1'.format(json.dumps(package))
         res = self.app.post('/api/action/package_create', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
         package_created = json.loads(res.body)['result']
         print package_created
         package_created['name'] = 'moo'
-        postparams = '%s=1' % json.dumps(package_created)
+        postparams = '{0!s}=1'.format(json.dumps(package_created))
         res = self.app.post('/api/action/package_update', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
 
@@ -282,7 +282,7 @@ class TestAction(WsgiAppCase):
         }
 
         wee = json.dumps(package)
-        postparams = '%s=1' % json.dumps(package)
+        postparams = '{0!s}=1'.format(json.dumps(package))
         res = self.app.post('/api/action/package_create', params=postparams,
                                      status=StatusCodes.STATUS_403_ACCESS_DENIED)
 
@@ -291,7 +291,7 @@ class TestAction(WsgiAppCase):
         anna_id = model.Package.by_name(u'annakarenina').id
         resource = {'package_id': anna_id, 'url': 'http://new_url'}
         api_key = model.User.get('testsysadmin').apikey.encode('utf8')
-        postparams = '%s=1' % json.dumps(resource)
+        postparams = '{0!s}=1'.format(json.dumps(resource))
         res = self.app.post('/api/action/resource_create', params=postparams,
                             extra_environ={'Authorization': api_key })
 
@@ -305,7 +305,7 @@ class TestAction(WsgiAppCase):
         resource = {'package_id': anna_id, 'url': 'new_url', 'created': 'bad_date'}
         api_key = model.User.get('testsysadmin').apikey.encode('utf8')
 
-        postparams = '%s=1' % json.dumps(resource)
+        postparams = '{0!s}=1'.format(json.dumps(resource))
         res = self.app.post('/api/action/resource_create', params=postparams,
                             extra_environ={'Authorization': api_key},
                             status=StatusCodes.STATUS_409_CONFLICT)
@@ -316,7 +316,7 @@ class TestAction(WsgiAppCase):
     def test_10_user_create_parameters_missing(self):
         user_dict = {}
 
-        postparams = '%s=1' % json.dumps(user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(user_dict))
         res = self.app.post('/api/action/user_create', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
                             status=StatusCodes.STATUS_409_CONFLICT)
@@ -335,7 +335,7 @@ class TestAction(WsgiAppCase):
                 'email':'me@test.org',
                       'password':'tes'} #Too short
 
-        postparams = '%s=1' % json.dumps(user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(user_dict))
         res = self.app.post('/api/action/user_create', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
                             status=StatusCodes.STATUS_409_CONFLICT)
@@ -359,7 +359,7 @@ class TestAction(WsgiAppCase):
                             'about':'Updated sysadmin user about'}
 
         #Normal users can update themselves
-        postparams = '%s=1' % json.dumps(normal_user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(normal_user_dict))
         res = self.app.post('/api/action/user_update', params=postparams,
                             extra_environ={'Authorization': str(self.normal_user.apikey)})
 
@@ -379,7 +379,7 @@ class TestAction(WsgiAppCase):
         assert not 'password' in result
 
         #Sysadmin users can update themselves
-        postparams = '%s=1' % json.dumps(sysadmin_user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(sysadmin_user_dict))
         res = self.app.post('/api/action/user_update', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
 
@@ -393,7 +393,7 @@ class TestAction(WsgiAppCase):
         assert result['about'] == sysadmin_user_dict['about']
 
         #Sysadmin users can update all users
-        postparams = '%s=1' % json.dumps(normal_user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(normal_user_dict))
         res = self.app.post('/api/action/user_update', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
 
@@ -407,7 +407,7 @@ class TestAction(WsgiAppCase):
         assert result['about'] == normal_user_dict['about']
 
         #Normal users can not update other users
-        postparams = '%s=1' % json.dumps(sysadmin_user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(sysadmin_user_dict))
         res = self.app.post('/api/action/user_update', params=postparams,
                             extra_environ={'Authorization': str(self.normal_user.apikey)},
                             status=StatusCodes.STATUS_403_ACCESS_DENIED)
@@ -442,7 +442,7 @@ class TestAction(WsgiAppCase):
                  )
 
         for test_call in test_calls:
-            postparams = '%s=1' % json.dumps(test_call['user_dict'])
+            postparams = '{0!s}=1'.format(json.dumps(test_call['user_dict']))
             res = self.app.post('/api/action/user_update', params=postparams,
                                 extra_environ={'Authorization': str(self.normal_user.apikey)},
                                 status=StatusCodes.STATUS_409_CONFLICT)
@@ -455,7 +455,7 @@ class TestAction(WsgiAppCase):
         CreateTestData.create_user(name)
         user = model.User.get(name)
         user_dict = {'id': user.id}
-        postparams = '%s=1' % json.dumps(user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(user_dict))
 
         res = self.app.post('/api/action/user_delete', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
@@ -467,7 +467,7 @@ class TestAction(WsgiAppCase):
 
     def test_user_delete_requires_data_dict_with_key_id(self):
         user_dict = {'name': 'normal_user'}
-        postparams = '%s=1' % json.dumps(user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(user_dict))
 
         res = self.app.post('/api/action/user_delete', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -484,7 +484,7 @@ class TestAction(WsgiAppCase):
         model.repo.commit()
 
         #Empty query
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         res = self.app.post(
             '/api/action/user_autocomplete',
             params=postparams,
@@ -494,7 +494,7 @@ class TestAction(WsgiAppCase):
         assert res_obj['success'] is False
 
         #Normal query
-        postparams = '%s=1' % json.dumps({'q':'joe'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'joe'}))
         res = self.app.post('/api/action/user_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['result'][0]['name'] == 'joeadmin'
@@ -502,7 +502,7 @@ class TestAction(WsgiAppCase):
 
     def test_17_bad_action(self):
         #Empty query
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         res = self.app.post('/api/action/bad_action_name', params=postparams,
                             status=400)
         res_obj = json.loads(res.body)
@@ -524,7 +524,7 @@ class TestAction(WsgiAppCase):
             'url': u'http://www.annakarenina.com',
         }
 
-        postparams = '%s=1' % json.dumps(package)
+        postparams = '{0!s}=1'.format(json.dumps(package))
         res = self.app.post('/api/action/package_create', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
         package_created = json.loads(res.body)['result']
@@ -532,7 +532,7 @@ class TestAction(WsgiAppCase):
         resource_created = package_created['resources'][0]
         new_resource_url = u'http://www.annakareinanew.com/download/'
         resource_created['url'] = new_resource_url
-        postparams = '%s=1' % json.dumps(resource_created)
+        postparams = '{0!s}=1'.format(json.dumps(resource_created))
         res = self.app.post('/api/action/resource_update', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
 
@@ -559,7 +559,7 @@ class TestAction(WsgiAppCase):
             'state': u'test_state',
             'error': u'test_error',
         }
-        postparams = '%s=1' % json.dumps(task_status)
+        postparams = '{0!s}=1'.format(json.dumps(task_status))
         res = self.app.post(
             '/api/action/task_status_update', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -572,7 +572,7 @@ class TestAction(WsgiAppCase):
 
         task_status_updated['id'] = task_status_id
         task_status_updated['value'] = u'test_value_2'
-        postparams = '%s=1' % json.dumps(task_status_updated)
+        postparams = '{0!s}=1'.format(json.dumps(task_status_updated))
         res = self.app.post(
             '/api/action/task_status_update', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -605,7 +605,7 @@ class TestAction(WsgiAppCase):
                 }
             ]
         }
-        postparams = '%s=1' % json.dumps(task_statuses)
+        postparams = '{0!s}=1'.format(json.dumps(task_statuses))
         res = self.app.post(
             '/api/action/task_status_update_many', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -620,7 +620,7 @@ class TestAction(WsgiAppCase):
 
     def test_22_task_status_normal_user_not_authorized(self):
         task_status = {}
-        postparams = '%s=1' % json.dumps(task_status)
+        postparams = '{0!s}=1'.format(json.dumps(task_status))
         res = self.app.post(
             '/api/action/task_status_update', params=postparams,
             extra_environ={'Authorization': str(self.normal_user.apikey)},
@@ -633,7 +633,7 @@ class TestAction(WsgiAppCase):
 
     def test_23_task_status_validation(self):
         task_status = {}
-        postparams = '%s=1' % json.dumps(task_status)
+        postparams = '{0!s}=1'.format(json.dumps(task_status))
         res = self.app.post(
             '/api/action/task_status_update', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -652,7 +652,7 @@ class TestAction(WsgiAppCase):
             'state': u'test_state',
             'error': u'test_error'
         }
-        postparams = '%s=1' % json.dumps(task_status)
+        postparams = '{0!s}=1'.format(json.dumps(task_status))
         res = self.app.post(
             '/api/action/task_status_update', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -660,7 +660,7 @@ class TestAction(WsgiAppCase):
         task_status_updated = json.loads(res.body)['result']
 
         # make sure show works when giving a task status ID
-        postparams = '%s=1' % json.dumps({'id': task_status_updated['id']})
+        postparams = '{0!s}=1'.format(json.dumps({'id': task_status_updated['id']}))
         res = self.app.post(
             '/api/action/task_status_show', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -672,11 +672,11 @@ class TestAction(WsgiAppCase):
         assert task_status_show == task_status_updated, (task_status_show, task_status_updated)
 
         # make sure show works when giving a (entity_id, task_type, key) tuple
-        postparams = '%s=1' % json.dumps({
+        postparams = '{0!s}=1'.format(json.dumps({
             'entity_id': task_status['entity_id'],
             'task_type': task_status['task_type'],
             'key': task_status['key']
-        })
+        }))
         res = self.app.post(
             '/api/action/task_status_show', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -698,14 +698,14 @@ class TestAction(WsgiAppCase):
             'state': u'test_state',
             'error': u'test_error'
         }
-        postparams = '%s=1' % json.dumps(task_status)
+        postparams = '{0!s}=1'.format(json.dumps(task_status))
         res = self.app.post(
             '/api/action/task_status_update', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
         )
         task_status_updated = json.loads(res.body)['result']
 
-        postparams = '%s=1' % json.dumps({'id': task_status_updated['id']})
+        postparams = '{0!s}=1'.format(json.dumps({'id': task_status_updated['id']}))
         res = self.app.post(
             '/api/action/task_status_delete', params=postparams,
             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -716,7 +716,7 @@ class TestAction(WsgiAppCase):
     def test_26_resource_show(self):
         pkg = model.Package.get('annakarenina')
         resource = pkg.resources[0]
-        postparams = '%s=1' % json.dumps({'id': resource.id})
+        postparams = '{0!s}=1'.format(json.dumps({'id': resource.id}))
         res = self.app.post('/api/action/resource_show', params=postparams)
         result = json.loads(res.body)['result']
 
@@ -760,7 +760,7 @@ class TestAction(WsgiAppCase):
 
 
     def test_30_status_show(self):
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         res = self.app.post('/api/action/status_show', params=postparams)
         status = json.loads(res.body)['result']
         assert_equal(status['site_title'], 'CKAN')
@@ -768,7 +768,7 @@ class TestAction(WsgiAppCase):
         assert_equal(status['site_url'], 'http://test.ckan.net')
 
     def test_31_bad_request_format(self):
-        postparams = '%s=1' % json.dumps('not a dict')
+        postparams = '{0!s}=1'.format(json.dumps('not a dict'))
         res = self.app.post('/api/action/package_list', params=postparams,
                             status=400)
         assert "Bad request - JSON Error: Request data JSON decoded to 'not a dict' but it needs to be a dictionary." in res.body, res.body
@@ -790,7 +790,7 @@ class TestAction(WsgiAppCase):
     def test_33_roles_show(self):
         anna = model.Package.by_name(u'annakarenina')
         annafan = model.User.by_name(u'annafan')
-        postparams = '%s=1' % json.dumps({'domain_object': anna.id})
+        postparams = '{0!s}=1'.format(json.dumps({'domain_object': anna.id}))
         res = self.app.post('/api/action/roles_show', params=postparams,
                             extra_environ={'Authorization': str(annafan.apikey)},
                             status=200)
@@ -806,8 +806,8 @@ class TestAction(WsgiAppCase):
     def test_34_roles_show_for_user(self):
         anna = model.Package.by_name(u'annakarenina')
         annafan = model.User.by_name(u'annafan')
-        postparams = '%s=1' % json.dumps({'domain_object': anna.id,
-                                          'user': 'annafan'})
+        postparams = '{0!s}=1'.format(json.dumps({'domain_object': anna.id,
+                                          'user': 'annafan'}))
         res = self.app.post('/api/action/roles_show', params=postparams,
                             extra_environ={'Authorization': str(annafan.apikey)},
                             status=200)
@@ -828,9 +828,9 @@ class TestAction(WsgiAppCase):
                                  ({'model': model, 'session': model.Session}, \
                                   {'domain_object': anna.id,
                                    'user': 'tester'})
-        postparams = '%s=1' % json.dumps({'user': 'tester',
+        postparams = '{0!s}=1'.format(json.dumps({'user': 'tester',
                                           'domain_object': anna.id,
-                                          'roles': ['reader']})
+                                          'roles': ['reader']}))
 
         res = self.app.post('/api/action/user_role_update', params=postparams,
                             extra_environ={'Authorization': str(annafan.apikey)},
@@ -854,9 +854,9 @@ class TestAction(WsgiAppCase):
         # Roles are no longer used so ignore this test
         raise SkipTest
         anna = model.Package.by_name(u'annakarenina')
-        postparams = '%s=1' % json.dumps({'user': 'tester',
+        postparams = '{0!s}=1'.format(json.dumps({'user': 'tester',
                                           'domain_object': anna.id,
-                                          'roles': ['editor']})
+                                          'roles': ['editor']}))
         # tester has no admin priviledges for this package
         res = self.app.post('/api/action/user_role_update', params=postparams,
                             extra_environ={'Authorization': 'tester'},
@@ -870,13 +870,13 @@ class TestAction(WsgiAppCase):
         roles_before = get_action('roles_show') \
                                  ({'model': model, 'session': model.Session}, \
                                   {'domain_object': anna.id})
-        postparams = '%s=1' % json.dumps({'domain_object': anna.id,
+        postparams = '{0!s}=1'.format(json.dumps({'domain_object': anna.id,
                                           'user_roles': [
                     {'user': 'annafan',
                      'roles': ('admin', 'editor')},
                     {'user': 'russianfan',
                      'roles': ['editor']},
-                                              ]})
+                                              ]}))
 
         res = self.app.post('/api/action/user_role_bulk_update', params=postparams,
                             extra_environ={'Authorization': str(annafan.apikey)},
@@ -1079,12 +1079,12 @@ class TestActionTermTranslation(WsgiAppCase):
         model.repo.rebuild_db()
 
     def test_1_update_single(self):
-        postparams = '%s=1' % json.dumps(
+        postparams = '{0!s}=1'.format(json.dumps(
             {"term" : "moo",
              "term_translation": "moo",
              "lang_code" : "fr"
             }
-        )
+        ))
 
         res = self.app.post('/api/action/term_translation_update', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -1092,12 +1092,12 @@ class TestActionTermTranslation(WsgiAppCase):
 
         assert json.loads(res.body)['success']
 
-        postparams = '%s=1' % json.dumps(
+        postparams = '{0!s}=1'.format(json.dumps(
             {"term" : "moo",
              "term_translation": "moomoo",
              "lang_code" : "fr"
             }
-        )
+        ))
 
         res = self.app.post('/api/action/term_translation_update', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -1105,12 +1105,12 @@ class TestActionTermTranslation(WsgiAppCase):
 
         assert json.loads(res.body)['success']
 
-        postparams = '%s=1' % json.dumps(
+        postparams = '{0!s}=1'.format(json.dumps(
             {"term" : "moo",
              "term_translation": "moomoo",
              "lang_code" : "en"
             }
-        )
+        ))
 
         res = self.app.post('/api/action/term_translation_update', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -1118,7 +1118,7 @@ class TestActionTermTranslation(WsgiAppCase):
 
         assert json.loads(res.body)['success']
 
-        postparams = '%s=1' % json.dumps({"terms" : ["moo"]})
+        postparams = '{0!s}=1'.format(json.dumps({"terms" : ["moo"]}))
 
         res = self.app.post('/api/action/term_translation_show', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
@@ -1134,7 +1134,7 @@ class TestActionTermTranslation(WsgiAppCase):
 
     def test_2_update_many(self):
 
-        postparams = '%s=1' % json.dumps({'data': [
+        postparams = '{0!s}=1'.format(json.dumps({'data': [
              {"term" : "many",
               "term_translation": "manymoo",
               "lang_code" : "fr"
@@ -1149,14 +1149,14 @@ class TestActionTermTranslation(WsgiAppCase):
              }
             ]
         }
-        )
+        ))
         res = self.app.post('/api/action/term_translation_update_many', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
                             status=200)
 
         assert json.loads(res.body)['result']['success'] == '3 rows updated', json.loads(res.body)
 
-        postparams = '%s=1' % json.dumps({"terms" : ["many"]})
+        postparams = '{0!s}=1'.format(json.dumps({"terms" : ["many"]}))
         res = self.app.post('/api/action/term_translation_show', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)},
                             status=200)
@@ -1190,7 +1190,7 @@ class TestActionPackageSearch(WsgiAppCase):
                 'rows': 20,
                 'start': 0,
             }
-        postparams = '%s=1' % json.dumps(params)
+        postparams = '{0!s}=1'.format(json.dumps(params))
         res = self.app.post('/api/action/package_search', params=postparams)
         res = json.loads(res.body)
         result = res['result']
@@ -1216,7 +1216,7 @@ class TestActionPackageSearch(WsgiAppCase):
                 'rows': 20,
                 'start': 0,
             }
-        postparams = '%s=1' % json.dumps(params)
+        postparams = '{0!s}=1'.format(json.dumps(params))
         res = self.app.post('/api/action/package_search', params=postparams)
         res = json.loads(res.body)
         assert_equal(res['success'], True)
@@ -1230,7 +1230,7 @@ class TestActionPackageSearch(WsgiAppCase):
                 'rows': 20,
                 'start': 0,
             }
-        postparams = '%s=1' % json.dumps(params)
+        postparams = '{0!s}=1'.format(json.dumps(params))
         res = self.app.post('/api/action/package_search', params=postparams)
         res = json.loads(res.body)
         assert_equal(res['success'], True)
@@ -1244,7 +1244,7 @@ class TestActionPackageSearch(WsgiAppCase):
                 'rows': 20,
                 'start': 0,
             }
-        postparams = '%s=1' % json.dumps(params)
+        postparams = '{0!s}=1'.format(json.dumps(params))
         res = self.app.post('/api/action/package_search', params=postparams)
         res = json.loads(res.body)
         assert_equal(res['success'], True)
@@ -1252,7 +1252,7 @@ class TestActionPackageSearch(WsgiAppCase):
         assert_equal(len(res['result']['search_facets']['groups']['items']), 2)
 
     def test_1_basic_no_params(self):
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         res = self.app.post('/api/action/package_search', params=postparams)
         res = json.loads(res.body)
         result = res['result']
@@ -1269,9 +1269,9 @@ class TestActionPackageSearch(WsgiAppCase):
         assert result['results'][0]['name'] in ('annakarenina', 'warandpeace')
 
     def test_2_bad_param(self):
-        postparams = '%s=1' % json.dumps({
+        postparams = '{0!s}=1'.format(json.dumps({
                 'sort':'metadata_modified',
-            })
+            }))
         res = self.app.post('/api/action/package_search', params=postparams,
                             status=409)
         assert '"message": "Search error:' in res.body, res.body
@@ -1281,20 +1281,20 @@ class TestActionPackageSearch(WsgiAppCase):
         assert 'sort' in res.body, res.body
 
     def test_3_bad_param(self):
-        postparams = '%s=1' % json.dumps({
+        postparams = '{0!s}=1'.format(json.dumps({
                 'weird_param':True,
-            })
+            }))
         res = self.app.post('/api/action/package_search', params=postparams,
                             status=400)
         assert '"message": "Search Query is invalid:' in res.body, res.body
         assert '"Invalid search parameters: [\'weird_param\']' in res.body, res.body
 
     def test_4_sort_by_metadata_modified(self):
-        search_params = '%s=1' % json.dumps({
+        search_params = '{0!s}=1'.format(json.dumps({
             'q': '*:*',
             'fl': 'name, metadata_modified',
             'sort': u'metadata_modified desc'
-        })
+        }))
 
         # modify warandpeace, check that it is the first search result
         rev = model.repo.new_revision()
@@ -1323,11 +1323,11 @@ class TestActionPackageSearch(WsgiAppCase):
 
         # add a tag to warandpeace, check that it is the first result
         pkg = model.Package.get('warandpeace')
-        pkg_params = '%s=1' % json.dumps({'id': pkg.id})
+        pkg_params = '{0!s}=1'.format(json.dumps({'id': pkg.id}))
         res = self.app.post('/api/action/package_show', params=pkg_params)
         pkg_dict = json.loads(res.body)['result']
         pkg_dict['tags'].append({'name': 'new-tag'})
-        pkg_params = '%s=1' % json.dumps(pkg_dict)
+        pkg_params = '{0!s}=1'.format(json.dumps(pkg_dict))
         res = self.app.post('/api/action/package_update', params=pkg_params,
                             extra_environ={'Authorization':  str(self.sysadmin_user.apikey)})
 
@@ -1402,10 +1402,10 @@ class TestSearchPluginInterface(WsgiAppCase):
 
     def test_search_plugin_interface_search(self):
         avoid = 'Tolstoy'
-        search_params = '%s=1' % json.dumps({
+        search_params = '{0!s}=1'.format(json.dumps({
             'q': '*:*',
             'extras' : {'ext_avoid':avoid}
-        })
+        }))
 
         res = self.app.post('/api/action/package_search', params=search_params)
 
@@ -1417,10 +1417,10 @@ class TestSearchPluginInterface(WsgiAppCase):
 
     def test_search_plugin_interface_abort(self):
 
-        search_params = '%s=1' % json.dumps({
+        search_params = '{0!s}=1'.format(json.dumps({
             'q': '*:*',
             'extras' : {'ext_abort':True}
-        })
+        }))
 
         res = self.app.post('/api/action/package_search', params=search_params)
 
@@ -1432,9 +1432,9 @@ class TestSearchPluginInterface(WsgiAppCase):
     def test_before_index(self):
 
         # no datasets get aaaaaaaa
-        search_params = '%s=1' % json.dumps({
+        search_params = '{0!s}=1'.format(json.dumps({
             'q': 'aaaaaaaa',
-        })
+        }))
 
         res = self.app.post('/api/action/package_search', params=search_params)
 
@@ -1443,9 +1443,9 @@ class TestSearchPluginInterface(WsgiAppCase):
         assert len(res_dict['results']) == 0
 
         # all datasets should get abcabcabc
-        search_params = '%s=1' % json.dumps({
+        search_params = '{0!s}=1'.format(json.dumps({
             'q': 'abcabcabc',
-        })
+        }))
         res = self.app.post('/api/action/package_search', params=search_params)
 
         res_dict = json.loads(res.body)['result']
@@ -1472,9 +1472,9 @@ class TestBulkActions(WsgiAppCase):
         ])
         model.Session.commit()
 
-        data_dict = '%s=1' % json.dumps({
+        data_dict = '{0!s}=1'.format(json.dumps({
             'name': 'org',
-        })
+        }))
         res = cls.app.post('/api/action/organization_create',
                             extra_environ={'Authorization': 'sysadmin'},
                             params=data_dict)
@@ -1482,10 +1482,10 @@ class TestBulkActions(WsgiAppCase):
 
         cls.package_ids = []
         for i in range(0,12):
-            data_dict = '%s=1' % json.dumps({
+            data_dict = '{0!s}=1'.format(json.dumps({
                 'name': 'name{i}'.format(i=i),
                 'owner_org': 'org',
-            })
+            }))
             res = cls.app.post('/api/action/package_create',
                                 extra_environ={'Authorization': 'sysadmin'},
                                 params=data_dict)
@@ -1497,10 +1497,10 @@ class TestBulkActions(WsgiAppCase):
         model.repo.rebuild_db()
 
     def test_01_make_private_then_public(self):
-        data_dict = '%s=1' % json.dumps({
+        data_dict = '{0!s}=1'.format(json.dumps({
             'datasets': self.package_ids,
             'org_id': self.org_id,
-        })
+        }))
         res = self.app.post('/api/action/bulk_update_private',
                             extra_environ={'Authorization': 'sysadmin'},
                             params=data_dict)
@@ -1527,10 +1527,10 @@ class TestBulkActions(WsgiAppCase):
 
     def test_02_bulk_delete(self):
 
-        data_dict = '%s=1' % json.dumps({
+        data_dict = '{0!s}=1'.format(json.dumps({
             'datasets': self.package_ids,
             'org_id': self.org_id,
-        })
+        }))
         res = self.app.post('/api/action/bulk_update_delete',
                             extra_environ={'Authorization': 'sysadmin'},
                             params=data_dict)
@@ -1572,7 +1572,7 @@ class TestResourceAction(WsgiAppCase):
         }
         package.update(kwargs)
 
-        postparams = '%s=1' % json.dumps(package)
+        postparams = '{0!s}=1'.format(json.dumps(package))
         res = self.app.post('/api/action/package_create', params=postparams,
                             extra_environ={'Authorization': 'tester'})
         return json.loads(res.body)['result']
@@ -1632,10 +1632,10 @@ class TestMember(WsgiAppCase):
         group = model.Group.get(group_id)
         url = '/api/action/group_member_create'
         role = 'member'
-        postparams = '%s=1' % json.dumps({
+        postparams = '{0!s}=1'.format(json.dumps({
             'id': group_id,
             'username': user_id,
-            'role': role})
+            'role': role}))
 
         res = self.app.post(url, params=postparams,
                             extra_environ={'Authorization': str(user.apikey)})
@@ -1675,7 +1675,7 @@ class TestRelatedAction(WsgiAppCase):
         }
         package.update(kwargs)
 
-        postparams = '%s=1' % json.dumps(package)
+        postparams = '{0!s}=1'.format(json.dumps(package))
         res = self.app.post('/api/action/package_create', params=postparams,
                             extra_environ={'Authorization': 'tester'})
         return json.loads(res.body)['result']

--- a/ckan/tests/logic/test_auth.py
+++ b/ckan/tests/logic/test_auth.py
@@ -44,15 +44,14 @@ class TestAuth(tests.WsgiAppCase):
 
     @classmethod
     def _call_api(cls, action, data, user, status=None):
-        params = '%s=1' % json.dumps(data)
-        res = cls.app.post('/api/action/%s' % action,
+        params = '{0!s}=1'.format(json.dumps(data))
+        res = cls.app.post('/api/action/{0!s}'.format(action),
                             params=params,
                             extra_environ={'Authorization': cls.apikeys[user]},
                             status=[200, 403, 409])
         if res.status != (status or 200):
             error = json.loads(res.body)['error']
-            raise AssertionError('Status was %s but should be %s. Error: %s' %
-                                 (res.status, status, error))
+            raise AssertionError('Status was {0!s} but should be {1!s}. Error: {2!s}'.format(res.status, status, error))
         return res
 
     @classmethod

--- a/ckan/tests/logic/test_tag.py
+++ b/ckan/tests/logic/test_tag.py
@@ -22,7 +22,7 @@ class TestAction(WsgiAppCase):
         model.repo.rebuild_db()
 
     def test_06a_tag_list(self):
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         res = self.app.post('/api/action/tag_list', params=postparams)
         resbody = json.loads(res.body)
         assert resbody['success'] is True
@@ -31,7 +31,7 @@ class TestAction(WsgiAppCase):
                 'tolerance'])
         assert '/api/3/action/help_show?name=tag_list' in resbody['help']
         #Get all fields
-        postparams = '%s=1' % json.dumps({'all_fields':True})
+        postparams = '{0!s}=1'.format(json.dumps({'all_fields':True}))
         res = self.app.post('/api/action/tag_list', params=postparams)
         res_obj = json.loads(res.body)
         pprint(res_obj)
@@ -69,7 +69,7 @@ class TestAction(WsgiAppCase):
         assert response.json['success'] == True
 
         # check that tag shows up in list
-        params = '%s=1' % json.dumps({'vocabulary_id': vocab_name})
+        params = '{0!s}=1'.format(json.dumps({'vocabulary_id': vocab_name}))
         res = self.app.post('/api/action/tag_list', params=params)
         body = json.loads(res.body)
         assert body['success'] is True
@@ -77,11 +77,11 @@ class TestAction(WsgiAppCase):
         assert '/api/3/action/help_show?name=tag_list' in body['help']
 
         # check that invalid vocab name results in a 404
-        params = '%s=1' % json.dumps({'vocabulary_id': 'invalid-vocab-name'})
+        params = '{0!s}=1'.format(json.dumps({'vocabulary_id': 'invalid-vocab-name'}))
         res = self.app.post('/api/action/tag_list', params=params, status=404)
 
     def test_07_tag_show(self):
-        postparams = '%s=1' % json.dumps({'id':'russian'})
+        postparams = '{0!s}=1'.format(json.dumps({'id':'russian'}))
         res = self.app.post('/api/action/tag_show', params=postparams)
         res_obj = json.loads(res.body)
         assert '/api/3/action/help_show?name=tag_show' in res_obj['help']
@@ -99,7 +99,7 @@ class TestAction(WsgiAppCase):
         expected_packages = ['annakarenina', 'warandpeace'] + (
             ['moo'] if 'moo' in packages else [])
 
-        assert sorted(packages) == sorted(expected_packages), "%s != %s" %(packages, expected_packages)
+        assert sorted(packages) == sorted(expected_packages), "{0!s} != {1!s}".format(packages, expected_packages)
 
     def test_07_flexible_tag_show(self):
         """
@@ -108,7 +108,7 @@ class TestAction(WsgiAppCase):
         The flexible tag is the tag with spaces, punctuation and foreign
         characters in its name, that's created in `ckan/lib/create_test_data.py`.
         """
-        postparams = '%s=1' % json.dumps({'id':u'Flexible \u30a1'})
+        postparams = '{0!s}=1'.format(json.dumps({'id':u'Flexible \u30a1'}))
         res = self.app.post('/api/action/tag_show', params=postparams)
         res_obj = json.loads(res.body)
         assert '/api/3/action/help_show?name=tag_show' in res_obj['help']
@@ -128,7 +128,7 @@ class TestAction(WsgiAppCase):
             'tags': u'tolstoy',
             'license': 'never_heard_of_it',
             }])
-        postparams = '%s=1' % json.dumps({'id':'tolstoy'})
+        postparams = '{0!s}=1'.format(json.dumps({'id':'tolstoy'}))
         res = self.app.post('/api/action/tag_show', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success'] == True
@@ -142,7 +142,7 @@ class TestAction(WsgiAppCase):
         assert_equal(pkg['isopen'], False)
 
     def test_08_user_create_not_authorized(self):
-        postparams = '%s=1' % json.dumps({'name':'test_create_from_action_api', 'password':'testpass'})
+        postparams = '{0!s}=1'.format(json.dumps({'name':'test_create_from_action_api', 'password':'testpass'}))
         res = self.app.post('/api/action/user_create', params=postparams,
                             status=StatusCodes.STATUS_403_ACCESS_DENIED)
         res_obj = json.loads(res.body)
@@ -156,7 +156,7 @@ class TestAction(WsgiAppCase):
                       'email': 'me@test.org',
                       'password':'testpass'}
 
-        postparams = '%s=1' % json.dumps(user_dict)
+        postparams = '{0!s}=1'.format(json.dumps(user_dict))
         res = self.app.post('/api/action/user_create', params=postparams,
                             extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
         res_obj = json.loads(res.body)
@@ -284,7 +284,7 @@ class TestAction(WsgiAppCase):
 
     def test_15_tag_autocomplete(self):
         #Empty query
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success'] == True
@@ -292,7 +292,7 @@ class TestAction(WsgiAppCase):
         assert '/api/3/action/help_show?name=tag_autocomplete' in res_obj['help']
 
         #Normal query
-        postparams = '%s=1' % json.dumps({'q':'r'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'r'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success'] == True
@@ -308,7 +308,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':'w'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'w'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -323,7 +323,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':'greek'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'greek'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -338,7 +338,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':'fullstop'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'fullstop'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -355,7 +355,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':'idea'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'idea'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -372,7 +372,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':'th sp'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':'th sp'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -389,7 +389,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':u'\u03b2'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':u'\u03b2'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -406,7 +406,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':u'stop.'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':u'stop.'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -423,7 +423,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':u'CAPITAL'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':u'CAPITAL'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']
@@ -436,7 +436,7 @@ class TestAction(WsgiAppCase):
             'license': 'never_heard_of_it',
             }])
 
-        postparams = '%s=1' % json.dumps({'q':u'lower case'})
+        postparams = '{0!s}=1'.format(json.dumps({'q':u'lower case'}))
         res = self.app.post('/api/action/tag_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success']

--- a/ckan/tests/logic/test_tag_vocab.py
+++ b/ckan/tests/logic/test_tag_vocab.py
@@ -101,7 +101,7 @@ class TestVocabFacets(object):
         model.repo.rebuild_db()
 
     def test_vocab_facets(self):
-        vocab_facet = 'vocab_%s' % TEST_VOCAB_NAME
+        vocab_facet = 'vocab_{0!s}'.format(TEST_VOCAB_NAME)
 
         context = {'model': model, 'session': model.Session}
         data = {

--- a/ckan/tests/misc/test_format_text.py
+++ b/ckan/tests/misc/test_format_text.py
@@ -32,42 +32,42 @@ class TestFormatText:
         instr = 'dataset:test-_pkg'
         exp = '<p><a href="/dataset/test-_pkg">dataset:test-_pkg</a>\n</p>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_internal_tag_link(self):
         """Asserts links like 'tag:test-tag' work"""
         instr = 'tag:test-tag foobar'
         exp = '<a href="/tag/test-tag">tag:test-tag</a> foobar'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_internal_tag_linked_with_quotes(self):
         """Asserts links like 'tag:"test-tag"' work"""
         instr = 'tag:"test-tag" foobar'
         exp = '<p><a href="/tag/test-tag">tag:&#34;test-tag&#34;</a> foobar\n</p>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_internal_tag_linked_with_quotes_and_space(self):
         """Asserts links like 'tag:"test tag"' work"""
         instr = 'tag:"test tag" foobar'
         exp = '<p><a href="/tag/test%20tag">tag:&#34;test tag&#34;</a> foobar\n</p>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_internal_tag_with_no_opening_quote_only_matches_single_word(self):
         """Asserts that without an opening quote only one word is matched"""
         instr = 'tag:test tag" foobar'  # should match 'tag:test'
         exp = '<a href="/tag/test">tag:test</a> tag" foobar'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_internal_tag_with_no_opening_quote_wont_match_the_closing_quote(self):
         """Asserts that 'tag:test" tag' is matched, but to 'tag:test'"""
         instr = 'tag:test" foobar'  # should match 'tag:test'
         exp = '<a href="/tag/test">tag:test</a>" foobar'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_internal_tag_with_no_closing_quote_does_not_match(self):
         """Asserts that without an opening quote only one word is matched"""
@@ -80,14 +80,14 @@ class TestFormatText:
         instr = 'tag:"Test- _." foobar'
         exp = '<p><a href="/tag/Test-%20_.">tag:&#34;Test- _.&#34;</a> foobar\n</p>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_tag_names_do_not_match_commas(self):
         """Asserts commas don't get matched as part of a tag name"""
         instr = 'tag:Test,tag foobar'
         exp = '<a href="/tag/Test">tag:Test</a>,tag foobar'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_tag_names_dont_match_non_space_whitespace(self):
         """Asserts that the only piece of whitespace matched in a tagname is a space"""
@@ -96,48 +96,48 @@ class TestFormatText:
             instr = 'tag:Bad' + ch + 'space'
             exp = '<a href="/tag/Bad">tag:Bad</a>'
             out = h.render_markdown(instr)
-            assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+            assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_tag_names_with_unicode_alphanumeric(self):
         """Asserts that unicode alphanumeric characters are captured"""
         instr = u'tag:"Japanese katakana \u30a1" blah'
         exp = u'<p><a href="/tag/Japanese%20katakana%20%E3%82%A1">tag:&#34;Japanese katakana \u30a1&#34;</a> blah\n</p>'
         out = h.render_markdown(instr)
-        assert exp in out, u'\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, u'\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_normal_link(self):
         instr = 'http://somelink/'
         exp = '<a href="http://somelink/" target="_blank" rel="nofollow">http://somelink/</a>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
         instr = 'http://somelink.com/#anchor'
         exp = '<a href="http://somelink.com/#anchor" target="_blank" rel="nofollow">http://somelink.com/#anchor</a>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
         instr = 'http://www.somelink.com/#anchor'
         exp = '<a href="http://www.somelink.com/#anchor" target="_blank" rel="nofollow">http://www.somelink.com/#anchor</a>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_auto_link(self):
         instr = 'http://somelink.com'
         exp = '<a href="http://somelink.com" target="_blank" rel="nofollow">http://somelink.com</a>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_auto_link_after_whitespace(self):
         instr = 'go to http://somelink.com'
         exp = 'go to <a href="http://somelink.com" target="_blank" rel="nofollow">http://somelink.com</a>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_malformed_link_1(self):
         instr = u'<a href=\u201dsomelink\u201d>somelink</a>'
         exp = '<p>somelink\n</p>'
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)
 
     def test_multiline_links(self):
         instr = u'''I get 10 times more traffic from [Google][] than from
@@ -151,4 +151,4 @@ class TestFormatText:
 </p>'''
         # NB when this is put into Genshi, it will close the tag for you.
         out = h.render_markdown(instr)
-        assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)
+        assert exp in out, '\nGot: {0!s}\nWanted: {1!s}'.format(out, exp)

--- a/ckan/tests/misc/test_mock_mail_server.py
+++ b/ckan/tests/misc/test_mock_mail_server.py
@@ -15,7 +15,7 @@ class TestMockMailServer(SmtpServerHarness, PylonsTestCase):
         if smtp_server:
             host, port = smtp_server.split(':')
             port = int(port) + int(str(hashlib.md5(cls.__name__).hexdigest())[0], 16)
-            config['smtp.test_server'] = '%s:%s' % (host, port)
+            config['smtp.test_server'] = '{0!s}:{1!s}'.format(host, port)
         SmtpServerHarness.setup_class()
         PylonsTestCase.setup_class()
 

--- a/ckan/tests/misc/test_sync.py
+++ b/ckan/tests/misc/test_sync.py
@@ -38,15 +38,15 @@ class _TestSync(TestController):
         count = 0
         while True:
             try:
-                f = urllib2.urlopen('http://localhost:5050%s' % offset)
+                f = urllib2.urlopen('http://localhost:5050{0!s}'.format(offset))
             except urllib2.URLError, e:
                 if hasattr(e, 'reason') and type(e.reason) == urllib2.socket.error:
                     # i.e. process not started up yet
                     count += 1
                     time.sleep(1)
-                    assert count < 5, '%s: %r; %r' % (offset, e, e.args)
+                    assert count < 5, '{0!s}: {1!r}; {2!r}'.format(offset, e, e.args)
                 else:
-                    print 'Error opening url: %s' % offset
+                    print 'Error opening url: {0!s}'.format(offset)
                     assert 0, e # Print exception
             else:
                 break
@@ -77,12 +77,12 @@ class _TestSync(TestController):
         assert last_sync_rev_id == None # no syncs yet
 
         # get revision ids since then
-        remote_rev_ids = self.sub_app_get_deserialized('%s/api/search/revision?since=%s' % (server, last_sync_rev_id))
+        remote_rev_ids = self.sub_app_get_deserialized('{0!s}/api/search/revision?since={1!s}'.format(server, last_sync_rev_id))
         assert len(remote_rev_ids) == 3
         remote_latest_rev_id = remote_rev_ids[-1]
 
         # get revision diffs
-        diffs = self.sub_app_get_deserialized('%s/api/diff/revision?diff=%s&oldid=%s' % (server, remote_latest_rev_id, last_sync_rev_id))
+        diffs = self.sub_app_get_deserialized('{0!s}/api/diff/revision?diff={1!s}&oldid={2!s}'.format(server, remote_latest_rev_id, last_sync_rev_id))
         assert len(diffs) == 3
                                       
         # apply diffs

--- a/ckan/tests/models/test_group.py
+++ b/ckan/tests/models/test_group.py
@@ -228,7 +228,7 @@ class TestGroupRevisions:
         assert len(all_rev) == num_descs, len(all_rev)
         for i, rev in enumerate(all_rev):
             assert rev.description == self.descriptions[num_descs - i - 1], \
-                '%s != %s' % (rev.description, self.descriptions[i])
+                '{0!s} != {1!s}'.format(rev.description, self.descriptions[i])
                 
     def test_2_extras(self):
         all_rev = self.grp.all_revisions

--- a/ckan/tests/models/test_license.py
+++ b/ckan/tests/models/test_license.py
@@ -4,10 +4,10 @@ import datetime
 class TestCase(object):
 
     def assert_unicode(self, val):
-        assert isinstance(val, unicode), "Value is not a unicode value: %s" % repr(val)
+        assert isinstance(val, unicode), "Value is not a unicode value: {0!s}".format(repr(val))
 
     def assert_datetime(self, val):
-        assert isinstance(val, datetime.datetime), "Value is not a datetime value: %s" % repr(val)
+        assert isinstance(val, datetime.datetime), "Value is not a datetime value: {0!s}".format(repr(val))
 
 
 class TestLicense(TestCase):

--- a/ckan/tests/models/test_package.py
+++ b/ckan/tests/models/test_package.py
@@ -271,7 +271,7 @@ class TestPackageRevisions:
         num_notes = len(self.notes)
         assert len(all_rev) == num_notes, len(all_rev)
         for i, rev in enumerate(all_rev):
-            assert rev.notes == self.notes[num_notes - i - 1], '%s != %s' % (rev.notes, self.notes[i])
+            assert rev.notes == self.notes[num_notes - i - 1], '{0!s} != {1!s}'.format(rev.notes, self.notes[i])
             #assert rev.extras['mykey'] == self.notes[num_notes - i - 1], '%s != %s' % (rev.extras['mykey'], self.notes[i])
 
 
@@ -368,10 +368,10 @@ class TestRelatedRevisions:
         assert diff.get('PackageExtra-c-value') == u'- \n+ d', diff
         assert diff.get('PackageExtra-c-state') == u'- \n+ active', diff
         def test_res(diff, res, field, expected_value):
-            key = 'Resource-%s-%s' % (res.id[:4], field)
+            key = 'Resource-{0!s}-{1!s}'.format(res.id[:4], field)
             got_value = diff.get(key)
-            expected_value = u'- \n+ %s' % expected_value
-            assert got_value == expected_value, 'Key: %s Got: %r Expected: %r' % (key, got_value, expected_value)
+            expected_value = u'- \n+ {0!s}'.format(expected_value)
+            assert got_value == expected_value, 'Key: {0!s} Got: {1!r} Expected: {2!r}'.format(key, got_value, expected_value)
         test_res(diff, self.res1, 'url', 'http://url1.com/edited')
         test_res(diff, self.res1, 'position', '0')
         test_res(diff, self.res1, 'format', 'xls')

--- a/ckan/tests/models/test_package_relationships.py
+++ b/ckan/tests/models/test_package_relationships.py
@@ -146,12 +146,12 @@ class TestComplicated:
 
     def test_rels(self):
         rels = model.Package.by_name(u'homer').relationships
-        assert len(rels) == 5, '%i: %s' % (len(rels), [rel for rel in rels])
+        assert len(rels) == 5, '{0:d}: {1!s}'.format(len(rels), [rel for rel in rels])
         def check(rels, subject, type, object):
             for rel in rels:
                 if rel.subject.name == subject and rel.type == type and rel.object.name == object:
                     return
-            assert 0, 'Could not find relationship in: %r' % rels
+            assert 0, 'Could not find relationship in: {0!r}'.format(rels)
         check(rels, 'homer', 'child_of', 'abraham')
         check(rels, 'bart', 'child_of', 'homer')
         check(rels, 'lisa', 'child_of', 'homer')
@@ -201,12 +201,12 @@ class TestComplicated:
     def test_01_rels(self):
         "audit the simpsons family relationships"
         rels = model.Package.by_name(u'homer').get_relationships()
-        assert len(rels) == 5, '%i: %s' % (len(rels), [rel for rel in rels])
+        assert len(rels) == 5, '{0:d}: {1!s}'.format(len(rels), [rel for rel in rels])
         def check(rels, subject, type, object):
             for rel in rels:
                 if rel.subject.name == subject and rel.type == type and rel.object.name == object:
                     return
-            assert 0, 'Could not find relationship in: %r' % rels
+            assert 0, 'Could not find relationship in: {0!r}'.format(rels)
         check(rels, 'homer', 'child_of', 'abraham')
         check(rels, 'bart', 'child_of', 'homer')
         check(rels, 'lisa', 'child_of', 'homer')
@@ -246,7 +246,7 @@ class TestComplicated:
         marge = model.Package.by_name(u"marge")
 
         rels = bart.get_relationships()
-        assert len(rels) == 0, "expected bart to have no relations, found %s" % rels
+        assert len(rels) == 0, "expected bart to have no relations, found {0!s}".format(rels)
 
         model.repo.new_revision()
         bart.add_relationship(u"child_of", homer)
@@ -254,15 +254,15 @@ class TestComplicated:
         model.repo.commit_and_remove()
 
         rels = bart.get_relationships()
-        assert len(rels) == 2, "expected bart to have one relation, found %s" % rels
+        assert len(rels) == 2, "expected bart to have one relation, found {0!s}".format(rels)
 
         q = model.Session.query(model.PackageRelationship).filter_by(subject=bart)
         count = q.count()
-        assert count == 2, "bart has %d relationships, expected 2" % count
+        assert count == 2, "bart has {0:d} relationships, expected 2".format(count)
         active = q.filter_by(state=model.State.ACTIVE).count()
-        assert active == 2, "bart has %d active relationships, expected 2" % active
+        assert active == 2, "bart has {0:d} active relationships, expected 2".format(active)
         deleted = q.filter_by(state=model.State.DELETED).count()
-        assert deleted == 0, "bart has %d deleted relationships, expect 0" % deleted
+        assert deleted == 0, "bart has {0:d} deleted relationships, expect 0".format(deleted)
 
     def test_04_relationship_display(self):
 

--- a/ckan/tests/models/test_user.py
+++ b/ckan/tests/models/test_user.py
@@ -160,13 +160,13 @@ class TestUser2(object):
 
             rev = model.repo.new_revision()
             pkg = model.Package.by_name(u'annakarenina')
-            pkg.notes = u'Changed notes %i' % i
+            pkg.notes = u'Changed notes {0:d}'.format(i)
             rev.author = u'annafan'
             model.repo.commit_and_remove()
 
             #and each time check that number_of_edits is correct
             assert model.User.by_name(u'annafan').number_of_edits() == i, \
-                   "annafan should have made %i edit(s)" % i
+                   "annafan should have made {0:d} edit(s)".format(i)
 
 
     def test_number_of_administered_packages(self):

--- a/ckan/tests/schema/test_schema.py
+++ b/ckan/tests/schema/test_schema.py
@@ -30,9 +30,9 @@ class TestPackage:
 
         for package_name, expected_errors in bad_names:
             errors = get_package_name_validation_errors(package_name)
-            errors = [err.replace('"%s"' % package_name, 'NAME') for err in errors]
+            errors = [err.replace('"{0!s}"'.format(package_name), 'NAME') for err in errors]
             assert errors==expected_errors, \
-                   '%r: %r != %r' % (package_name, errors, expected_errors)
+                   '{0!r}: {1!r} != {2!r}'.format(package_name, errors, expected_errors)
 
     def test_version_validation(self):
         context = {'model': ckan.model,
@@ -54,9 +54,9 @@ class TestPackage:
 
         for package_version, expected_errors in bad_versions:
             errors = get_package_version_validation_errors(package_version)
-            errors = [err.replace('"%s"' % package_version, 'VERSION') for err in errors]
+            errors = [err.replace('"{0!s}"'.format(package_version), 'VERSION') for err in errors]
             assert errors==expected_errors, \
-                   '%r: %r != %r' % (package_version, errors, expected_errors)
+                   '{0!r}: {1!r} != {2!r}'.format(package_version, errors, expected_errors)
 
 
     def test_convert_from_extras(self):
@@ -107,7 +107,7 @@ class TestTag:
 
         for tag_name, expected_errors in bad_names:
             errors = get_tag_validation_errors(tag_name)
-            errors = [err.replace('"%s"' % tag_name, 'TAG') for err in errors]
+            errors = [err.replace('"{0!s}"'.format(tag_name), 'TAG') for err in errors]
             assert_equal(errors, expected_errors)
 
     def test_tag_string_parsing(self):

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -53,7 +53,7 @@ def output_errors(filename, errors):
 
 def show_fails(msg, errors):
     if errors:
-        msg = ['\n%s' % msg]
+        msg = ['\n{0!s}'.format(msg)]
         for error in errors:
             msg.append(errors[error])
         msg.append('\n\nFailing Files:\n==============')
@@ -63,7 +63,7 @@ def show_fails(msg, errors):
 
 def show_passing(msg, errors):
     if errors:
-        raise Exception('\n%s\n\n' % msg + '\n'.join(sorted(errors)))
+        raise Exception('\n{0!s}\n\n'.format(msg) + '\n'.join(sorted(errors)))
 
 
 def cs_filter(f, filter_, ignore_comment_lines=True):
@@ -123,7 +123,7 @@ class TestBadSpellings(object):
     def process(cls):
         blacklist = cls.BAD_SPELLING_BLACKLIST_FILES
         re_bad_spelling = re.compile(
-            r'(%s)' % '|'.join([x for x in cls.BAD_SPELLINGS]),
+            r'({0!s})'.format('|'.join([x for x in cls.BAD_SPELLINGS])),
             flags=re.IGNORECASE
         )
         files = itertools.chain.from_iterable([
@@ -139,10 +139,9 @@ class TestBadSpellings(object):
                     bad_words = []
                     for m in matches:
                         if m not in bad_words:
-                            bad_words.append('%s use %s' %
-                                             (m, cls.BAD_SPELLINGS[m.lower()]))
+                            bad_words.append('{0!s} use {1!s}'.format(m, cls.BAD_SPELLINGS[m.lower()]))
                     bad = ', '.join(bad_words)
-                    errors.append('ln:%s \t%s\n<%s>' % (count, line[:-1], bad))
+                    errors.append('ln:{0!s} \t{1!s}\n<{2!s}>'.format(count, line[:-1], bad))
                 count += 1
             if errors and not filename in blacklist:
                 cls.fails[filename] = output_errors(filename, errors)
@@ -195,7 +194,7 @@ class TestNastyString(object):
             errors = []
             for line in cs_filter(f, 'nasty_string'):
                 if re_nasty_str.search(line):
-                    errors.append('ln:%s \t%s' % (count, line[:-1]))
+                    errors.append('ln:{0!s} \t{1!s}'.format(count, line[:-1]))
                 count += 1
             if errors and not filename in blacklist:
                 cls.fails[filename] = output_errors(filename, errors)
@@ -340,8 +339,7 @@ class TestImportStar(object):
             errors = []
             for line in f:
                 if re_import_star.search(line):
-                    errors.append('%s ln:%s import *\n\t%s'
-                                  % (filename, count, line))
+                    errors.append('{0!s} ln:{1!s} import *\n\t{2!s}'.format(filename, count, line))
                 count += 1
             if errors and not filename in blacklist:
                 cls.fails[filename] = output_errors(filename, errors)
@@ -717,7 +715,7 @@ class TestPep8(object):
             if len(parts) == 3:
                 location, error, desc = parts
                 line_no = location.split(':')[1]
-                errors.append('%s ln:%s %s' % (error, line_no, desc))
+                errors.append('{0!s} ln:{1!s} {2!s}'.format(error, line_no, desc))
         return errors
 
     @classmethod
@@ -824,11 +822,11 @@ class TestActionAuth(object):
         def get_functions(module_root):
             fns = {}
             for auth_module_name in ['get', 'create', 'update', 'delete']:
-                module_path = '%s.%s' % (module_root, auth_module_name,)
+                module_path = '{0!s}.{1!s}'.format(module_root, auth_module_name)
                 try:
                     module = __import__(module_path)
                 except ImportError:
-                    print ('No auth module for action "%s"' % auth_module_name)
+                    print ('No auth module for action "{0!s}"'.format(auth_module_name))
 
                 for part in module_path.split('.')[1:]:
                     module = getattr(module, part)
@@ -839,7 +837,7 @@ class TestActionAuth(object):
                     if v.__module__ != module_path:
                         continue
                     if not key.startswith('_'):
-                        name = '%s: %s' % (auth_module_name, key)
+                        name = '{0!s}: {1!s}'.format(auth_module_name, key)
                         fns[name] = v
             return fns
         cls.actions = get_functions('logic.action')
@@ -848,26 +846,24 @@ class TestActionAuth(object):
     def test_actions_have_auth_fn(self):
         actions_no_auth = set(self.actions.keys()) - set(self.auths.keys())
         actions_no_auth -= set(self.ACTION_NO_AUTH_BLACKLIST)
-        assert not actions_no_auth, 'These actions have no auth function\n%s' \
-            % '\n'.join(sorted(list(actions_no_auth)))
+        assert not actions_no_auth, 'These actions have no auth function\n{0!s}'.format('\n'.join(sorted(list(actions_no_auth))))
 
     def test_actions_have_auth_fn_blacklist(self):
         actions_no_auth = set(self.actions.keys()) & set(self.auths.keys())
         actions_no_auth &= set(self.ACTION_NO_AUTH_BLACKLIST)
         assert not actions_no_auth, 'These actions blacklisted but ' + \
-            'shouldn\'t be \n%s' % '\n'.join(sorted(list(actions_no_auth)))
+            'shouldn\'t be \n{0!s}'.format('\n'.join(sorted(list(actions_no_auth))))
 
     def test_auths_have_action_fn(self):
         auths_no_action = set(self.auths.keys()) - set(self.actions.keys())
         auths_no_action -= set(self.AUTH_NO_ACTION_BLACKLIST)
-        assert not auths_no_action, 'These auth functions have no action\n%s' \
-            % '\n'.join(sorted(list(auths_no_action)))
+        assert not auths_no_action, 'These auth functions have no action\n{0!s}'.format('\n'.join(sorted(list(auths_no_action))))
 
     def test_auths_have_action_fn_blacklist(self):
         auths_no_action = set(self.auths.keys()) & set(self.actions.keys())
         auths_no_action &= set(self.AUTH_NO_ACTION_BLACKLIST)
         assert not auths_no_action, 'These auths functions blacklisted but' + \
-            ' shouldn\'t be \n%s' % '\n'.join(sorted(list(auths_no_action)))
+            ' shouldn\'t be \n{0!s}'.format('\n'.join(sorted(list(auths_no_action))))
 
     def test_fn_signatures(self):
         errors = []
@@ -879,8 +875,7 @@ class TestActionAuth(object):
                 if name not in self.ACTION_FN_SIGNATURES_BLACKLIST:
                     errors.append(name)
         assert not errors, 'These action functions have the wrong function' + \
-            ' signature, should be (context, data_dict)\n%s' \
-            % '\n'.join(sorted(errors))
+            ' signature, should be (context, data_dict)\n{0!s}'.format('\n'.join(sorted(errors)))
 
     def test_fn_docstrings(self):
         errors = []
@@ -888,8 +883,7 @@ class TestActionAuth(object):
             if not getattr(fn, '__doc__', None):
                 if name not in self.ACTION_NO_DOC_STR_BLACKLIST:
                     errors.append(name)
-        assert not errors, 'These action functions need docstrings\n%s' \
-            % '\n'.join(sorted(errors))
+        assert not errors, 'These action functions need docstrings\n{0!s}'.format('\n'.join(sorted(errors)))
 
 
 class TestBadExceptions(object):
@@ -936,7 +930,7 @@ class TestBadExceptions(object):
             errors = []
             for line in f:
                 if re_nasty_exception.search(line):
-                    errors.append('ln:%s \t%s' % (count, line[:-1]))
+                    errors.append('ln:{0!s} \t{1!s}'.format(count, line[:-1]))
                 count += 1
             if errors and not filename in blacklist:
                 cls.fails[filename] = output_errors(filename, errors)

--- a/ckan/tests/test_dumper.py
+++ b/ckan/tests/test_dumper.py
@@ -51,7 +51,7 @@ class TestSimpleDump(TestController):
 
     def assert_correct_field_order(self, res):
         correct_field_order = ('id', 'name', 'title', 'version', 'url')
-        field_position = [res.find('"%s"' % field) for field in correct_field_order]
+        field_position = [res.find('"{0!s}"'.format(field)) for field in correct_field_order]
         field_position_sorted = field_position[:]
         field_position_sorted.sort()
         assert field_position == field_position_sorted, field_position
@@ -64,7 +64,7 @@ class TestDumper(object):
         CreateTestData.create()
         d = Dumper()
         ts = int(time())
-        self.outpath = '/tmp/mytestdump-%s.js' % ts
+        self.outpath = '/tmp/mytestdump-{0!s}.js'.format(ts)
         if os.path.exists(self.outpath):
             os.remove(self.outpath)
         d.dump_json(self.outpath)
@@ -79,9 +79,9 @@ class TestDumper(object):
         assert dumpeddata['version'] == ckan.__version__
         tables = dumpeddata.keys()
         for key in ['Package', 'Tag', 'Group', 'Member', 'PackageExtra']:
-            assert key in tables, '%r not in %s' % (key, tables)
+            assert key in tables, '{0!r} not in {1!s}'.format(key, tables)
         for key in ['User']:
-            assert key not in tables, '%s should not be in %s' % (key, tables)
+            assert key not in tables, '{0!s} should not be in {1!s}'.format(key, tables)
         assert len(dumpeddata['Package']) == 2, len(dumpeddata['Package'])
         assert len(dumpeddata['Tag']) == 3, len(dumpeddata['Tag'])
         assert len(dumpeddata['PackageRevision']) == 2, len(dumpeddata['PackageRevision'])

--- a/ckan/tests/wsgi_ckanclient.py
+++ b/ckan/tests/wsgi_ckanclient.py
@@ -26,7 +26,7 @@ class WsgiCkanClient(CkanClient):
 
     def open_url(self, location, data=None, headers={}, method=None):
         if self.is_verbose:
-            print "ckanclient: Opening %s" % location
+            print "ckanclient: Opening {0!s}".format(location)
         self.last_location = location
 
         if data != None:
@@ -36,7 +36,7 @@ class WsgiCkanClient(CkanClient):
 
         # Make header values ascii strings
         for key, value in headers.items():
-            headers[key] = str('%s' % value)
+            headers[key] = str('{0!s}'.format(value))
 
         method = req.get_method()
         kwargs = {'status':'*', 'headers':headers}
@@ -52,34 +52,33 @@ class WsgiCkanClient(CkanClient):
                 assert not data
                 res = self.app.delete(location, **kwargs)
             else:
-                raise ClientError('No Paste interface for method \'%s\': %s' % \
-                                  (method, location))
+                raise ClientError('No Paste interface for method \'{0!s}\': {1!s}'.format(method, location))
         except paste.fixture.AppError, inst:
-            print "ckanclient: error: %s" % inst
+            print "ckanclient: error: {0!s}".format(inst)
             self.last_http_error = inst
             self.last_status = 500
             self.last_message = repr(inst.args)
         else:
             if res.status not in (200, 201):
                 print "ckanclient: Received HTTP error code from CKAN resource."
-                print "ckanclient: location: %s" % location
-                print "ckanclient: response code: %s" % res.status
-                print "ckanclient: request headers: %s" % headers
-                print "ckanclient: request data: %s" % data
-                print "ckanclient: error: %s" % res
+                print "ckanclient: location: {0!s}".format(location)
+                print "ckanclient: response code: {0!s}".format(res.status)
+                print "ckanclient: request headers: {0!s}".format(headers)
+                print "ckanclient: request data: {0!s}".format(data)
+                print "ckanclient: error: {0!s}".format(res)
                 self.last_http_error = res
                 self.last_status = res.status
                 self.last_message = res.body
             else:
-                print "ckanclient: OK opening CKAN resource: %s" % location
+                print "ckanclient: OK opening CKAN resource: {0!s}".format(location)
                 self.last_status = res.status
-                print 'ckanclient: last status %s' % self.last_status
+                print 'ckanclient: last status {0!s}'.format(self.last_status)
                 self.last_body = res.body
-                print 'ckanclient: last body %s' % self.last_body
+                print 'ckanclient: last body {0!s}'.format(self.last_body)
                 self.last_headers = dict(res.headers)
-                print 'ckanclient: last headers %s' % self.last_headers
+                print 'ckanclient: last headers {0!s}'.format(self.last_headers)
                 content_type = self.last_headers['Content-Type']
-                print 'ckanclient: content type: %s' % content_type
+                print 'ckanclient: content type: {0!s}'.format(content_type)
                 is_json_response = False
                 if 'json' in content_type:
                     is_json_response = True
@@ -87,7 +86,7 @@ class WsgiCkanClient(CkanClient):
                     self.last_message = self._loadstr(self.last_body)
                 else:
                     self.last_message = self.last_body
-                print 'ckanclient: last message %s' % self.last_message
+                print 'ckanclient: last message {0!s}'.format(self.last_message)
         if self.last_status not in (200, 201):
             raise CkanApiError(self.last_message)
 

--- a/ckanext-hdx_org_group/ckanext/hdx_org_group/controllers/browse_controller.py
+++ b/ckanext-hdx_org_group/ckanext/hdx_org_group/controllers/browse_controller.py
@@ -108,8 +108,8 @@ class BrowseController(base.BaseController):
                 context, {'vocabulary_id': 'Topics'})
         except NotFound, e:
             all_topics = []
-            log.error('ERROR getting vocabulary named Topics: %r' %
-                      str(e.extra_msg))
+            log.error('ERROR getting vocabulary named Topics: {0!r}'.format(
+                      str(e.extra_msg)))
         return all_topics
 
     def _get_dataset_counts(self, context, package_type):

--- a/ckanext-hdx_org_group/ckanext/hdx_org_group/helpers/organization_helper.py
+++ b/ckanext-hdx_org_group/ckanext/hdx_org_group/helpers/organization_helper.py
@@ -651,7 +651,7 @@ def hdx_group_or_org_create(context, data_dict, is_org=False):
     }
     logic.get_action('member_create')(member_create_context, member_dict)
 
-    log.debug('Created object %s' % group.name)
+    log.debug('Created object {0!s}'.format(group.name))
     return model_dictize.group_dictize(group, context)
 
 

--- a/ckanext-hdx_package/ckanext/hdx_package/command.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/command.py
@@ -50,7 +50,7 @@ class MigrateCommand(p.toolkit.CkanCommand):
             filename = url_parts[len(url_parts)-1]
             response = requests.get(url, stream=True)
             if response.status_code != 200:
-                print "failed to fetch %s (code %s)" % (url,
+                print "failed to fetch {0!s} (code {1!s})".format(url,
                                                         response.status_code)
                 continue
             resource_upload = ResourceUpload({'id': id})
@@ -76,4 +76,4 @@ class MigrateCommand(p.toolkit.CkanCommand):
                             "url = '%s' where id = '%s' and "
                             "revision_id = '%s'" % (filename, id, revision_id))
             Session.commit()
-            print "Saved url %s" % url
+            print "Saved url {0!s}".format(url)

--- a/ckanext-hdx_package/ckanext/hdx_package/controllers/dataset_controller.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/controllers/dataset_controller.py
@@ -605,7 +605,7 @@ class DatasetController(PackageController):
             if not ctype:
                 # An unknown format, we'll carry on in case it is a
                 # revision specifier and re-constitute the original id
-                id = "%s.%s" % (id, format)
+                id = "{0!s}.{1!s}".format(id, format)
                 ctype, format = "text/html; charset=utf-8", "html"
         else:
             ctype, format = self._content_type_from_accept()
@@ -1064,8 +1064,8 @@ class DatasetController(PackageController):
         dataset_type = c.pkg_dict['type'] or 'dataset'
 
         # TODO: find a nicer way of doing this
-        c.datastore_api = '%s/api/action' % config.get(
-            'ckan.site_url', '').rstrip('/')
+        c.datastore_api = '{0!s}/api/action'.format(config.get(
+            'ckan.site_url', '').rstrip('/'))
 
         c.related_count = c.pkg.related_count
 

--- a/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
@@ -158,7 +158,7 @@ def _activity_list(context, activity_stream, extra_vars):
                 if object_type == 'PackageExtra':
                     object_type = 'package_extra'
 
-                new_activity_type = '%s %s' % (detail['activity_type'],
+                new_activity_type = '{0!s} {1!s}'.format(detail['activity_type'],
                                                object_type.lower())
                 if new_activity_type in activity_streams.activity_stream_string_functions:
                     activity_type = new_activity_type
@@ -463,7 +463,7 @@ def package_create(context, data_dict):
     context["package"] = pkg
     # this is added so that the rest controller can make a new location
     context["id"] = pkg.id
-    log.debug('Created object %s' % pkg.name)
+    log.debug('Created object {0!s}'.format(pkg.name))
 
     # Make sure that a user provided schema is not used on package_show
     context.pop('schema', None)
@@ -535,9 +535,9 @@ def filesize_format(size_in_bytes):
 
         for unit in ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
             if size < d:
-                return "%3.1f%s" % (size, unit)
+                return "{0:3.1f}{1!s}".format(size, unit)
             size /= d
-        return "%.1f%s" % (size, 'Yi')
+        return "{0:.1f}{1!s}".format(size, 'Yi')
     except Exception, e:
         log.warn('Error occured when formatting the numner {}. Error {}'.format(size_in_bytes, str(e)))
         return size_in_bytes

--- a/ckanext-hdx_package/ckanext/hdx_package/helpers/update.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/helpers/update.py
@@ -134,7 +134,7 @@ def package_update(context, data_dict):
     if not context.get('defer_commit'):
         model.repo.commit()
 
-    log.debug('Updated object %s' % pkg.name)
+    log.debug('Updated object {0!s}'.format(pkg.name))
 
     return_id_only = context.get('return_id_only', False)
 

--- a/ckanext-hdx_pages/ckanext/hdx_pages/controllers/custom_page.py
+++ b/ckanext-hdx_pages/ckanext/hdx_pages/controllers/custom_page.py
@@ -209,7 +209,7 @@ class PagesController(HDXSearchController):
                 fq = '"{}" {}'.format(values_list[0], fq)
             elif key in get_default_facet_titles().keys():
                 for value in values_list:
-                    fq += '%s:"%s" ' % (key, value)
+                    fq += '{0!s}:"{1!s}" '.format(key, value)
             elif key == 'sort':
                 search_params['default_sort_by'] = values_list[0]
             elif key == 'ext_page_size':

--- a/ckanext-hdx_search/ckanext/hdx_search/controllers/search_controller.py
+++ b/ckanext-hdx_search/ckanext/hdx_search/controllers/search_controller.py
@@ -279,7 +279,7 @@ class HDXSearchController(PackageController):
                         and len(value) and not param.startswith('_'):
                     if not param.startswith('ext_'):
                         c.fields.append((param, value))
-                        fq += ' %s:"%s"' % (param, value)
+                        fq += ' {0!s}:"{1!s}"'.format(param, value)
                         if param not in c.fields_grouped:
                             c.fields_grouped[param] = [value]
                         else:
@@ -348,12 +348,12 @@ class HDXSearchController(PackageController):
         for facet in c.search_facets.keys():
             limit = 1000
             try:
-                limit = int(request.params.get('_%s_limit' % facet,
+                limit = int(request.params.get('_{0!s}_limit'.format(facet),
                                                1000))
             except ValueError:
                 abort(400, _('Parameter "{parameter_name}" is not '
                              'an integer').format(
-                    parameter_name='_%s_limit' % facet
+                    parameter_name='_{0!s}_limit'.format(facet)
                 ))
             c.search_facets_limits[facet] = limit
 

--- a/ckanext-hdx_theme/ckanext/hdx_theme/helpers/helpers.py
+++ b/ckanext-hdx_theme/ckanext/hdx_theme/helpers/helpers.py
@@ -405,7 +405,7 @@ def hdx_follow_link(obj_type, obj_id, extra_text, cls=None):
     # If the user is logged in show the follow/unfollow button
     if c.user:
         context = {'model': model, 'session': model.Session, 'user': c.user}
-        action = 'am_following_%s' % obj_type
+        action = 'am_following_{0!s}'.format(obj_type)
         following = logic.get_action(action)(context, {'id': obj_id})
         return h.snippet('search/snippets/follow_link.html',
                          following=following,
@@ -422,7 +422,7 @@ def follow_status(obj_type, obj_id):
     # If the user is logged in show the follow/unfollow button
     if c.user:
         context = {'model': model, 'session': model.Session, 'user': c.user}
-        action = 'am_following_%s' % obj_type
+        action = 'am_following_{0!s}'.format(obj_type)
         following = logic.get_action(action)(context, {'id': obj_id})
         return following
     return False
@@ -468,7 +468,7 @@ def hdx_follow_button(obj_type, obj_id, **kw):
     # If the user is logged in show the follow/unfollow button
     if c.user:
         context = {'model': model, 'session': model.Session, 'user': c.user}
-        action = 'am_following_%s' % obj_type
+        action = 'am_following_{0!s}'.format(obj_type)
         following = logic.get_action(action)(context, {'id': obj_id})
         follow_extra_text = _('This Data')
         if kw and 'follow_extra_text' in kw:

--- a/ckanext-hdx_users/ckanext/hdx_users/controllers/mailer.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/controllers/mailer.py
@@ -23,8 +23,8 @@ class MailerException(Exception):
 def add_msg_niceties(recipient_name, body, sender_name, sender_url):
     footer = '<br><p><a href="https://data.hdx.rwlabs.org">Humanitarian Data Exchange</a></p>' + '<p>Sign up for our <a href="http://eepurl.com/PlJgH">Blogs</a> | <a href="https://twitter.com/humdata">Follow us on Twitter</a> | <a href="mailto:hdx@un.org" target="_top">Contact us</a></p>'
     return _(u"Dear %s,") % recipient_name \
-           + u"\r\n\r\n%s\r\n\r\n" % body \
-           + u"\r\n%s" % footer
+           + u"\r\n\r\n{0!s}\r\n\r\n".format(body) \
+           + u"\r\n{0!s}".format(footer)
 
 
 def _mail_recipient(recipient_name, recipient_email,
@@ -37,10 +37,10 @@ def _mail_recipient(recipient_name, recipient_email,
     subject = Header(subject.encode('utf-8'), 'utf-8')
     msg['Subject'] = subject
     msg['From'] = _("%s <%s>") % (sender_name, mail_from)
-    recipient = u"%s <%s>" % (recipient_name, recipient_email)
+    recipient = u"{0!s} <{1!s}>".format(recipient_name, recipient_email)
     msg['To'] = Header(recipient, 'utf-8')
     msg['Date'] = Utils.formatdate(time())
-    msg['X-Mailer'] = "CKAN %s" % ckan.__version__
+    msg['X-Mailer'] = "CKAN {0!s}".format(ckan.__version__)
     part = MIMEText(body, 'html')
     msg.attach(part)
 
@@ -86,7 +86,7 @@ def _mail_recipient(recipient_name, recipient_email,
         log.info("Sent email to {0}".format(recipient_email))
 
     except smtplib.SMTPException, e:
-        msg = '%r' % e
+        msg = '{0!r}'.format(e)
         log.exception(msg)
         raise MailerException(msg)
     finally:

--- a/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
+++ b/ckanext-hdx_users/ckanext/hdx_users/tests/test_emails/test_email_access.py
@@ -389,7 +389,7 @@ class TestPasswordReset(SmtpServerHarness, PylonsTestCase):
         if smtp_server:
             host, port = smtp_server.split(':')
             port = int(port) + int(str(hashlib.md5(cls.__name__).hexdigest())[0], 16)
-            config['smtp.test_server'] = '%s:%s' % (host, port)
+            config['smtp.test_server'] = '{0!s}:{1!s}'.format(host, port)
         SmtpServerHarness.setup_class()
         PylonsTestCase.setup_class()
         cls._load_plugins()

--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -31,10 +31,10 @@ class DatapusherCommand(cli.CkanCommand):
         answer = cli.query_yes_no(question, default=None)
         if answer == 'yes':
             resources_ids = datastore_db.get_all_resources_ids_in_datastore()
-            print 'Submitting %d datastore resources' % len(resources_ids)
+            print 'Submitting {0:d} datastore resources'.format(len(resources_ids))
             datapusher_submit = p.toolkit.get_action('datapusher_submit')
             for resource_id in resources_ids:
-                print ('Submitting %s...' % resource_id),
+                print ('Submitting {0!s}...'.format(resource_id)),
                 data_dict = {
                     'resource_id': resource_id,
                     'ignore_hash': True,

--- a/ckanext/datapusher/tests/test.py
+++ b/ckanext/datapusher/tests/test.py
@@ -58,7 +58,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         data = {
             'resource': {'package_id': package.id}
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=200)
@@ -122,7 +122,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'resource_id': resource.id,
             'resource': {'package_id': package.id}
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -184,7 +184,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                 'resource_id': resource.id
             }
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(user.apikey)}
         res = self.app.post('/api/action/datapusher_hook', params=postparams,
                             extra_environ=auth, status=200)
@@ -217,7 +217,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         data = {
             'status': 'success',
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
 
         self.app.post('/api/action/datapusher_hook', params=postparams,
                       status=409)
@@ -226,7 +226,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         data = {
             'metadata': {'resource_id': 'res_id'},
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
 
         self.app.post('/api/action/datapusher_hook', params=postparams,
                       status=409)
@@ -236,7 +236,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'status': 'success',
             'metadata': {}
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
 
         self.app.post('/api/action/datapusher_hook', params=postparams,
                       status=409)

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -440,7 +440,7 @@ def create_indexes(context, data_dict):
         fields_string = u', '.join(
             ['(("{0}").json::text)'.format(field)
                 if field in json_fields else
-                '"%s"' % field
+                '"{0!s}"'.format(field)
                 for field in index_fields])
         sql_index_strings.append(sql_index_string.format(
             res_id=data_dict['resource_id'],
@@ -624,8 +624,8 @@ def upsert_data(context, data_dict):
     fields = _get_fields(context, data_dict)
     field_names = _pluck('id', fields)
     records = data_dict['records']
-    sql_columns = ", ".join(['"%s"' % name.replace(
-        '%', '%%') for name in field_names] + ['"_full_text"'])
+    sql_columns = ", ".join(['"{0!s}"'.format(name.replace(
+        '%', '%%')) for name in field_names] + ['"_full_text"'])
 
     if method == _INSERT:
         rows = []
@@ -962,7 +962,7 @@ def search_data(context, data_dict):
         distinct = ''
 
     if sort:
-        sort_clause = 'ORDER BY %s' % (', '.join(sort)).replace('%', '%%')
+        sort_clause = 'ORDER BY {0!s}'.format((', '.join(sort)).replace('%', '%%'))
     else:
         sort_clause = ''
 

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -45,7 +45,7 @@ def list_of_strings_or_lists(key, data, errors, context):
         raise df.Invalid('Not a list')
     for x in value:
         if not isinstance(x, basestring) and not isinstance(x, list):
-            raise df.Invalid('%s: %s' % ('Neither a string nor a list', x))
+            raise df.Invalid('{0!s}: {1!s}'.format('Neither a string nor a list', x))
 
 
 def list_of_strings_or_string(key, data, errors, context):

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -384,7 +384,7 @@ class DatastorePlugin(p.SingletonPlugin):
         where = self._where(data_dict, fields_types)
 
         select_cols = [u'"{0}"'.format(field_id) for field_id in field_ids] +\
-                      [u'count(*) over() as "_full_count" %s' % rank_column]
+                      [u'count(*) over() as "_full_count" {0!s}'.format(rank_column)]
 
         query_dict['distinct'] = data_dict.get('distinct', False)
         query_dict['select'] += select_cols

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -206,14 +206,14 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         data = {
             'resource_id': resource.id
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             status=403)
         res_dict = json.loads(res.body)
         assert res_dict['success'] is False
 
     def test_create_empty_fails(self):
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -228,7 +228,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'fields': [{'id': 'book', 'type': 'text'},
                        {'id': 'author', 'type': 'text'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -241,7 +241,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'fields': [{'id': 'book', 'type': 'text'},
                        {'id': 'author', 'type': 'text'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -254,7 +254,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'resource_id': resource.id,
             'aliases': u'myalias'
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=200)
@@ -267,7 +267,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'resource_id': resource.id,
             'aliases': u'myalias'
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -280,7 +280,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'resource_id': resource.id,
             'aliases': model.Package.get('annakarenina').resources[0].id
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -294,7 +294,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'fields': [{'id': 'book', 'type': 'int['},  # this is invalid
                        {'id': 'author', 'type': 'INVALID'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -313,7 +313,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                 'fields': [{'id': 'book', 'type': 'text'},
                            {'id': field_name, 'type': 'text'}]
             }
-            postparams = '%s=1' % json.dumps(data)
+            postparams = '{0!s}=1'.format(json.dumps(data))
             res = self.app.post('/api/action/datastore_create', params=postparams,
                                 extra_environ=auth, status=409)
             res_dict = json.loads(res.body)
@@ -328,7 +328,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'records': [{'book': 'annakarenina', 'author': 'tolstoy'},
                         {'book': 'warandpeace', 'published': '1869'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -343,7 +343,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                        {'id': 'author', 'type': 'text'}],
             'records': ['bad']  # treat author as null
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -361,7 +361,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                         [],
                         {'book': 'warandpeace'}]  # treat author as null
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -378,7 +378,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'fields': [{'id': 'book', 'type': 'text'},
                        {'id': 'author', 'type': 'text'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -393,7 +393,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'fields': [{'id': 'book', 'type': 'text'},
                        {'id': 'author', 'type': 'text'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -408,7 +408,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'fields': [{'id': 'book', 'type': 'text'},
                        {'id': 'author', 'type': 'text'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -421,7 +421,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'aliases': 'new_alias',
             'fields': [{'id': 'more books', 'type': 'text'}]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -442,14 +442,14 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                         {'boo%k': 'warandpeace'}]  # treat author as null
         }
         ### Firstly test to see whether resource has no datastore table yet
-        postparams = '%s=1' % json.dumps({'id': resource.id})
+        postparams = '{0!s}=1'.format(json.dumps({'id': resource.id}))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/resource_show', params=postparams,
                             extra_environ=auth)
         res_dict = json.loads(res.body)
         assert res_dict['result']['datastore_active'] is False
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -497,7 +497,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         self.Session.remove()
 
         # check to test to see if resource now has a datastore table
-        postparams = '%s=1' % json.dumps({'id': resource.id})
+        postparams = '{0!s}=1'.format(json.dumps({'id': resource.id}))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/resource_show', params=postparams,
                             extra_environ=auth)
@@ -510,7 +510,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'records': [{'boo%k': 'hagji murat', 'author': ['tolstoy']}]
         }
 
-        postparams = '%s=1' % json.dumps(data2)
+        postparams = '{0!s}=1'.format(json.dumps(data2))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -545,7 +545,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'indexes': ['rating']
         }
 
-        postparams = '%s=1' % json.dumps(data3)
+        postparams = '{0!s}=1'.format(json.dumps(data3))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -574,7 +574,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'primary_key': 'boo%k'
         }
 
-        postparams = '%s=1' % json.dumps(data4)
+        postparams = '{0!s}=1'.format(json.dumps(data4))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -591,7 +591,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'primary_key': ''
         }
 
-        postparams = '%s=1' % json.dumps(data5)
+        postparams = '{0!s}=1'.format(json.dumps(data5))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, expect_errors=True)
@@ -625,7 +625,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'indexes': ['characters']
         }
 
-        postparams = '%s=1' % json.dumps(data6)
+        postparams = '{0!s}=1'.format(json.dumps(data6))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, expect_errors=True)
@@ -646,7 +646,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'indexes': ['characters']
         }
 
-        postparams = '%s=1' % json.dumps(data7)
+        postparams = '{0!s}=1'.format(json.dumps(data7))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, expect_errors=True)
@@ -661,7 +661,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             'records': [{'boo%k': 'warandpeace', 'author': '99% good'}]
         }
 
-        postparams = '%s=1' % json.dumps(data8)
+        postparams = '{0!s}=1'.format(json.dumps(data8))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, expect_errors=True)
@@ -684,7 +684,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                         {'boo%k': 'warandpeace'}]  # treat author as null
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -699,7 +699,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         data = {
             'id': res['resource_id']
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         res = self.app.post('/api/action/resource_show', params=postparams)
         res_dict = json.loads(res.body)
 
@@ -712,7 +712,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         data = {
             'resource_id': resource.id
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth, status="*")  # ignore status
@@ -729,7 +729,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                         {'book': 'crime', 'author': ['tolstoy', 'dostoevsky']},
                         {'book': 'warandpeace'}]  # treat author as null
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -766,7 +766,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                          'nested': [1, 2], 'date2': '2005-12-01'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -807,7 +807,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
                          'count3': 432, 'date2': '2005-12-01'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)
@@ -833,7 +833,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
             ],
             "method": "insert",
         }
-        postparams = '%s=1' % json.dumps(data_dict)
+        postparams = '{0!s}=1'.format(json.dumps(data_dict))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth, status=409)

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -52,7 +52,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
         p.unload('datastore')
 
     def _create(self):
-        postparams = '%s=1' % json.dumps(self.data)
+        postparams = '{0!s}=1'.format(json.dumps(self.data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -62,7 +62,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
 
     def _delete(self):
         data = {'resource_id': self.data['resource_id']}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth)
@@ -94,7 +94,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
         self.Session.remove()
 
     def test_delete_invalid_resource_id(self):
-        postparams = '%s=1' % json.dumps({'resource_id': 'bad'})
+        postparams = '{0!s}=1'.format(json.dumps({'resource_id': 'bad'}))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth, status=404)
@@ -108,7 +108,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
         # try and delete just the 'warandpeace' row
         data = {'resource_id': resource_id,
                 'filters': {'book': 'warandpeace'}}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth)
@@ -125,7 +125,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
         # shouldn't delete anything
         data = {'resource_id': resource_id,
                 'filters': {'book': 'annakarenina', 'author': 'bad'}}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth)
@@ -142,7 +142,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
         # delete the 'annakarenina' row and also only use id
         data = {'id': resource_id,
                 'filters': {'book': 'annakarenina', 'author': 'tolstoy'}}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth)
@@ -166,7 +166,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
                 'invalid-column-name': 'value'
             }
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth, status=409)
@@ -185,7 +185,7 @@ class TestDatastoreDelete(tests.WsgiAppCase):
                 'invalid-column-name': 'value'
             }
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_delete', params=postparams,
                             extra_environ=auth, status=409)

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -46,7 +46,7 @@ class TestDatastoreDump(object):
                         {u'b\xfck': 'warandpeace', 'author': 'tolstoy',
                          'nested': {'a': 'b'}}]
         }
-        postparams = '%s=1' % json.dumps(cls.data)
+        postparams = '{0!s}=1'.format(json.dumps(cls.data))
         auth = {'Authorization': str(cls.sysadmin_user.apikey)}
         res = cls.app.post('/api/action/datastore_create', params=postparams,
                            extra_environ=auth)

--- a/ckanext/datastore/tests/test_interface.py
+++ b/ckanext/datastore/tests/test_interface.py
@@ -78,8 +78,7 @@ class TestInterfaces(object):
             {'age': 20}, {'age': 30}, {'age': 40}
         ]
         resource = self._create_datastore_resource(records)
-        sql_inject = '1=1); DELETE FROM "%s"; COMMIT; SELECT * FROM "%s";--' \
-                     % (resource['id'], resource['id'])
+        sql_inject = '1=1); DELETE FROM "{0!s}"; COMMIT; SELECT * FROM "{1!s}";--'.format(resource['id'], resource['id'])
         filters = {
             'insecure_filter': sql_inject
         }
@@ -145,8 +144,7 @@ class TestInterfaces(object):
             {'age': 20}, {'age': 30}, {'age': 40}
         ]
         resource = self._create_datastore_resource(records)
-        sql_inject = '1=1); DELETE FROM "%s"; SELECT * FROM "%s";--' \
-                     % (resource['id'], resource['id'])
+        sql_inject = '1=1); DELETE FROM "{0!s}"; SELECT * FROM "{1!s}";--'.format(resource['id'], resource['id'])
         filters = {
             'age': 20,
             'insecure_filter': sql_inject

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -135,7 +135,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                         'nested': {'a': 'b'}, 'rating with %': '99%'}
                        ]
         }
-        postparams = '%s=1' % json.dumps(cls.data)
+        postparams = '{0!s}=1'.format(json.dumps(cls.data))
         auth = {'Authorization': str(cls.sysadmin_user.apikey)}
         res = cls.app.post('/api/action/datastore_create', params=postparams,
                            extra_environ=auth)
@@ -175,7 +175,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
     def test_search_basic(self):
         data = {'resource_id': self.data['resource_id']}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -187,7 +187,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
         # search with parameter id should yield the same results
         data = {'id': self.data['resource_id']}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -217,10 +217,10 @@ class TestDatastoreSearch(tests.WsgiAppCase):
              'url': 'https://www.example.com/',
              'package_id': package['id']})
 
-        postparams = '%s=1' % json.dumps({
+        postparams = '{0!s}=1'.format(json.dumps({
             'resource_id': resource['id'],
             'force': True
-        })
+        }))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -228,7 +228,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         assert res_dict['success'] is True
 
         data = {'resource_id': resource['id']}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=403)
@@ -237,7 +237,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
     def test_search_alias(self):
         data = {'resource_id': self.data['aliases']}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -249,7 +249,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_invalid_field(self):
         data = {'resource_id': self.data['resource_id'],
                 'fields': [{'id': 'bad'}]}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -259,7 +259,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_fields(self):
         data = {'resource_id': self.data['resource_id'],
                 'fields': [u'b\xfck']}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -272,7 +272,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
         data = {'resource_id': self.data['resource_id'],
                 'fields': u'b\xfck, author'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -287,7 +287,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         data = {'resource_id': self.data['resource_id'],
                 'fields': [u'author'],
                 'distinct': True}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -300,7 +300,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_filters(self):
         data = {'resource_id': self.data['resource_id'],
                 'filters': {u'b\xfck': 'annakarenina'}}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -313,7 +313,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_filter_array_field(self):
         data = {'resource_id': self.data['resource_id'],
                 'filters': {u'characters': [u'Princess Anna', u'Sergius']}}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -328,7 +328,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                 'filters': {
                     u'b\xfck': [u'annakarenina', u'warandpeace']
                 }}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -341,7 +341,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_filter_normal_field_passing_multiple_values_in_array(self):
         data = {'resource_id': self.data['resource_id'],
                 'filters': {u'b\xfck': [u'annakarenina', u'warandpeace']}}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -365,7 +365,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         data = {'resource_id': self.data['resource_id'],
                 # invalid because author is not a numeric field
                 'filters': {u'author': 42}}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -375,7 +375,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_sort(self):
         data = {'resource_id': self.data['resource_id'],
                 'sort': u'b\xfck asc, author desc'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -388,7 +388,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
         data = {'resource_id': self.data['resource_id'],
                 'sort': [u'b\xfck desc', '"author" asc']}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
         res_dict = json.loads(res.body)
@@ -401,7 +401,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_invalid(self):
         data = {'resource_id': self.data['resource_id'],
                 'sort': u'f\xfc\xfc asc'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -414,7 +414,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_limit(self):
         data = {'resource_id': self.data['resource_id'],
                 'limit': 1}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -427,7 +427,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_invalid_limit(self):
         data = {'resource_id': self.data['resource_id'],
                 'limit': 'bad'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -436,7 +436,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
         data = {'resource_id': self.data['resource_id'],
                 'limit': -1}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -447,7 +447,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         data = {'resource_id': self.data['resource_id'],
                 'limit': 1,
                 'offset': 1}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -460,7 +460,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
     def test_search_invalid_offset(self):
         data = {'resource_id': self.data['resource_id'],
                 'offset': 'bad'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -469,7 +469,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
         data = {'resource_id': self.data['resource_id'],
                 'offset': -1}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -480,7 +480,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         data = {'resource_id': self.data['resource_id'],
                 'q': 'annakarenina'}
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -496,7 +496,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
         data = {'resource_id': self.data['resource_id'],
                 'q': 'tolstoy'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
         res_dict = json.loads(res.body)
@@ -523,7 +523,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         data = {'resource_id': self.data['resource_id'],
                 'plain': True,
                 'q': 'tolstoy annakarenina'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
         res_dict = json.loads(res.body)
@@ -544,7 +544,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                 'q': {u"b\xfck": "annakarenina"}
                 }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -559,7 +559,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                 'q': u'{"b\xfck": "annakarenina"}'
                 }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -574,7 +574,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                 'q': {'invalid_field_name': 'value'}
                 }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -586,7 +586,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                 'q': {'author': ['invalid', 'value']}
                 }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -595,7 +595,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
     def test_search_table_metadata(self):
         data = {'resource_id': "_table_metadata"}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -607,7 +607,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
             'resource_id': self.data['resource_id'],
             'filters': 'the-filter'
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -622,7 +622,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                 'invalid-column-name': 'value'
             }
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -637,7 +637,7 @@ class TestDatastoreSearch(tests.WsgiAppCase):
                 'invalid-column-name'
             ]
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth, status=409)
@@ -679,7 +679,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
               {'id': 5, 'date': '2011-06-02', 'x': 6, 'y': 12, 'z': 18, 'country': 'DE', 'title': 'sixth 53.56', 'lat':51.04, 'lon':7.9}
             ]
         )
-        postparams = '%s=1' % json.dumps(cls.data)
+        postparams = '{0!s}=1'.format(json.dumps(cls.data))
         auth = {'Authorization': str(cls.normal_user.apikey)}
         res = cls.app.post('/api/action/datastore_create', params=postparams,
                            extra_environ=auth)
@@ -694,7 +694,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
     def test_search_full_text(self):
         data = {'resource_id': self.data['resource_id'],
                 'q': 'DE'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -705,7 +705,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
         data = {'resource_id': self.data['resource_id'],
                 'plain': 'False',
                 'q': 'DE | UK'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -715,7 +715,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
     def test_full_text_search_on_integers_within_text_strings(self):
         data = {'resource_id': self.data['resource_id'],
                 'q': '99'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -725,7 +725,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
     def test_full_text_search_on_integers(self):
         data = {'resource_id': self.data['resource_id'],
                 'q': '4'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -735,7 +735,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
     def test_full_text_search_on_decimal_within_text_strings(self):
         data = {'resource_id': self.data['resource_id'],
                 'q': '53.56'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -745,7 +745,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
     def test_full_text_search_on_decimal(self):
         data = {'resource_id': self.data['resource_id'],
                 'q': '52.56'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -755,7 +755,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
     def test_full_text_search_on_date(self):
         data = {'resource_id': self.data['resource_id'],
                 'q': '2011-01-01'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -765,7 +765,7 @@ class TestDatastoreFullTextSearch(tests.WsgiAppCase):
     def test_full_text_search_on_json_like_string_succeeds(self):
         data = {'resource_id': self.data['resource_id'],
                 'q': '"{}"'}
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.post('/api/action/datastore_search', params=postparams,
                             extra_environ=auth)
@@ -806,7 +806,7 @@ class TestDatastoreSQL(tests.WsgiAppCase):
                         'author': 'tolstoy',
                         'nested': {'a': 'b'}}]
         }
-        postparams = '%s=1' % json.dumps(cls.data)
+        postparams = '{0!s}=1'.format(json.dumps(cls.data))
         auth = {'Authorization': str(cls.sysadmin_user.apikey)}
         res = cls.app.post('/api/action/datastore_create', params=postparams,
                            extra_environ=auth)
@@ -976,10 +976,10 @@ class TestDatastoreSQL(tests.WsgiAppCase):
              'url': 'https://www.example.com/',
              'package_id': package['id']})
 
-        postparams = '%s=1' % json.dumps({
+        postparams = '{0!s}=1'.format(json.dumps({
             'resource_id': resource['id'],
             'force': True
-        })
+        }))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)
@@ -1017,10 +1017,10 @@ class TestDatastoreSQL(tests.WsgiAppCase):
              'url': 'https://www.example.co.uk/',
              'package_id': package['id']})
 
-        postparams = '%s=1' % json.dumps({
+        postparams = '{0!s}=1'.format(json.dumps({
             'resource_id': resource['id'],
             'force': True
-        })
+        }))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_create', params=postparams,
                             extra_environ=auth)

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -45,7 +45,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
                         'nested': {'a':'b'}}
                        ]
             }
-        postparams = '%s=1' % json.dumps(cls.data)
+        postparams = '{0!s}=1'.format(json.dumps(cls.data))
         auth = {'Authorization': str(cls.sysadmin_user.apikey)}
         res = cls.app.post('/api/action/datastore_create', params=postparams,
                            extra_environ=auth)
@@ -65,14 +65,14 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
         data = {
             'resource_id': self.data['resource_id']
         }
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             status=403)
         res_dict = json.loads(res.body)
         assert res_dict['success'] is False
 
     def test_upsert_empty_fails(self):
-        postparams = '%s=1' % json.dumps({})
+        postparams = '{0!s}=1'.format(json.dumps({}))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)
@@ -98,7 +98,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
                 u'b\xfck': hhguide}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -129,7 +129,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
             'records': [{'published': '1979-1-1', u'b\xfck': hhguide}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -154,7 +154,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
             'records': [{u'b\xfck': hhguide, 'published': None}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -178,7 +178,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
             'records': [{'author': 'tolkien', u'b\xfck': 'the hobbit'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -202,7 +202,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
             'records': [{'author': 'tol % kien', u'b\xfck': 'the % hobbit'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -217,7 +217,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
             'records': [{'author': 'tolkien'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)
@@ -232,7 +232,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
             'records': [{u'b\xfck': 'annakarenina', 'dummy': 'tolkien'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)
@@ -251,7 +251,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
                 u'b\xfck': hhguide}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -297,7 +297,7 @@ class TestDatastoreInsert(tests.WsgiAppCase):
                         'nested': {'a':'b'}}
                        ]
             }
-        postparams = '%s=1' % json.dumps(cls.data)
+        postparams = '{0!s}=1'.format(json.dumps(cls.data))
         auth = {'Authorization': str(cls.sysadmin_user.apikey)}
         res = cls.app.post('/api/action/datastore_create', params=postparams,
                            extra_environ=auth)
@@ -320,7 +320,7 @@ class TestDatastoreInsert(tests.WsgiAppCase):
             'records': [{u'b\xfck': 'the hobbit', 'dummy': 'tolkien'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)
@@ -335,7 +335,7 @@ class TestDatastoreInsert(tests.WsgiAppCase):
             'records': [{u'b\xfck': 'annakarenina'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)
@@ -355,7 +355,7 @@ class TestDatastoreInsert(tests.WsgiAppCase):
                 u'b\xfck': hhguide}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -404,7 +404,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
                         u'b\xfck': hhguide}
                        ]
             }
-        postparams = '%s=1' % json.dumps(cls.data)
+        postparams = '{0!s}=1'.format(json.dumps(cls.data))
         auth = {'Authorization': str(cls.sysadmin_user.apikey)}
         res = cls.app.post('/api/action/datastore_create', params=postparams,
                            extra_environ=auth)
@@ -437,7 +437,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
                 u'b\xfck': hhguide}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -466,7 +466,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
             'records': [{'published': '1979-1-1', u'b\xfck': hhguide}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -491,7 +491,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
             'records': [{u'b\xfck': hhguide, 'published': None}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth)
@@ -516,7 +516,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
             'records': [{'author': 'tolkien'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)
@@ -531,7 +531,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
             'records': [{u'b\xfck': '', 'author': 'tolkien'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)
@@ -546,7 +546,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
             'records': [{u'b\xfck': 'annakarenina', 'dummy': 'tolkien'}]
         }
 
-        postparams = '%s=1' % json.dumps(data)
+        postparams = '{0!s}=1'.format(json.dumps(data))
         auth = {'Authorization': str(self.sysadmin_user.apikey)}
         res = self.app.post('/api/action/datastore_upsert', params=postparams,
                             extra_environ=auth, status=409)

--- a/ckanext/example_idatasetform/tests/test_controllers.py
+++ b/ckanext/example_idatasetform/tests/test_controllers.py
@@ -40,7 +40,7 @@ class TestPackageController(helpers.FunctionalTestBase):
         response = submit_and_follow(app, form, env, 'save')
         # just check it has finished the edit, rather than being sent on to the
         # resource create/edit form.
-        assert_equal(response.req.path, '/dataset/%s' % dataset['name'])
+        assert_equal(response.req.path, '/dataset/{0!s}'.format(dataset['name']))
 
         pkg = model.Package.by_name(dataset['name'])
         assert_equal(pkg.extras['custom_text'], u'bar')
@@ -58,7 +58,7 @@ class TestPackageController(helpers.FunctionalTestBase):
         response = submit_and_follow(app, form, env, 'save')
         # just check it has finished the edit, rather than being sent on to the
         # resource create/edit form.
-        assert_equal(response.req.path, '/dataset/%s' % dataset['name'])
+        assert_equal(response.req.path, '/dataset/{0!s}'.format(dataset['name']))
 
         pkg = model.Package.by_name(dataset['name'])
         assert_equal(pkg.extras['testkey'], u'bar')

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -171,10 +171,10 @@ class MultilingualDataset(SingletonPlugin):
         lang_set.remove(current_lang)
 
         # weight current lang more highly
-        query_fields = 'title_%s^8 text_%s^4' % (current_lang, current_lang)
+        query_fields = 'title_{0!s}^8 text_{1!s}^4'.format(current_lang, current_lang)
 
         for lang in lang_set:
-            query_fields += ' title_%s^2 text_%s' % (lang, lang)
+            query_fields += ' title_{0!s}^2 text_{1!s}'.format(lang, lang)
 
         search_params['qf'] = query_fields
 

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -175,4 +175,4 @@ def _assert_schema_exists_and_has_keys(schema, expected_keys):
     keys.sort()
     expected_keys.sort()
 
-    assert keys == expected_keys, '%s != %s' % (keys, expected_keys)
+    assert keys == expected_keys, '{0!s} != {1!s}'.format(keys, expected_keys)

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -67,12 +67,12 @@ def proxy_resource(context, data_dict):
                            detail='Content is too large to be proxied.')
 
     except requests.exceptions.HTTPError, error:
-        details = 'Could not proxy resource. Server responded with %s %s' % (
+        details = 'Could not proxy resource. Server responded with {0!s} {1!s}'.format(
             error.response.status_code, error.response.reason)
         base.abort(409, detail=details)
     except requests.exceptions.ConnectionError, error:
         details = '''Could not proxy resource because a
-                            connection error occurred. %s''' % error
+                            connection error occurred. {0!s}'''.format(error)
         base.abort(502, detail=details)
     except requests.exceptions.Timeout, error:
         details = 'Could not proxy resource because the connection timed out.'

--- a/ckanext/resourceproxy/tests/test_proxy.py
+++ b/ckanext/resourceproxy/tests/test_proxy.py
@@ -165,7 +165,7 @@ class TestProxyPrettyfied(tests.WsgiAppCase, unittest.TestCase):
         schemes = ['file', 'ws']
 
         for scheme in schemes:
-            url = '%s://ckan.org' % scheme
+            url = '{0!s}://ckan.org'.format(scheme)
             data_dict = set_resource_url(url)
             non_proxied_url = proxy.get_proxified_resource_url(data_dict)
             proxied_url = proxy.get_proxified_resource_url(data_dict, scheme)

--- a/ckanext/stats/controller.py
+++ b/ckanext/stats/controller.py
@@ -25,19 +25,19 @@ class StatsController(BaseController):
         # Used in new CKAN templates gives more control to the templates for formatting.
         c.raw_packages_by_week = []
         for week_date, num_packages, cumulative_num_packages in c.num_packages_by_week:
-            c.packages_by_week.append('[new Date(%s), %s]' % (week_date.replace('-', ','), cumulative_num_packages))
+            c.packages_by_week.append('[new Date({0!s}), {1!s}]'.format(week_date.replace('-', ','), cumulative_num_packages))
             c.raw_packages_by_week.append({'date': h.date_str_to_datetime(week_date), 'total_packages': cumulative_num_packages})
 
         c.all_package_revisions = []
         c.raw_all_package_revisions = []
         for week_date, revs, num_revisions, cumulative_num_revisions in c.package_revisions_by_week:
-            c.all_package_revisions.append('[new Date(%s), %s]' % (week_date.replace('-', ','), num_revisions))
+            c.all_package_revisions.append('[new Date({0!s}), {1!s}]'.format(week_date.replace('-', ','), num_revisions))
             c.raw_all_package_revisions.append({'date': h.date_str_to_datetime(week_date), 'total_revisions': num_revisions})
 
         c.new_datasets = []
         c.raw_new_datasets = []
         for week_date, pkgs, num_packages, cumulative_num_packages in c.new_packages_by_week:
-            c.new_datasets.append('[new Date(%s), %s]' % (week_date.replace('-', ','), num_packages))
+            c.new_datasets.append('[new Date({0!s}), {1!s}]'.format(week_date.replace('-', ','), num_packages))
             c.raw_new_datasets.append({'date': h.date_str_to_datetime(week_date), 'new_packages': num_packages})
 
         return p.toolkit.render('ckanext/stats/index.html')

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -322,7 +322,7 @@ class RevisionStats(object):
             return weekly_pkg_ids
         if cache_enabled:
             week_commences = cls.get_date_week_started(datetime.date.today())
-            key = '%s_by_week_%s' % (cls._object_type, week_commences.strftime(DATE_FORMAT))
+            key = '{0!s}_by_week_{1!s}'.format(cls._object_type, week_commences.strftime(DATE_FORMAT))
             objects_by_week_ = our_cache.get_value(key=key,
                                     createfunc=objects_by_week)
         else:

--- a/ckanext/test_tag_vocab_plugin.py
+++ b/ckanext/test_tag_vocab_plugin.py
@@ -76,7 +76,7 @@ class MockVocabTagsPlugin(plugins.SingletonPlugin):
                 tags = c.pkg_dict.get('vocab_tags_selected', [])
                 for tag in tags:
                     stream = stream | Transformer('body')\
-                        .append(HTML('<p>%s</p>' % tag))
+                        .append(HTML('<p>{0!s}</p>'.format(tag)))
         if routes.get('controller') == 'package' \
             and routes.get('action') == 'edit':
                 # add vocabs tag select box to edit page
@@ -84,9 +84,9 @@ class MockVocabTagsPlugin(plugins.SingletonPlugin):
                 selected_tags = c.pkg_dict.get('vocab_tags_selected', [])
                 for tag in c.vocab_tags:
                     if tag in selected_tags:
-                        html += '<option selected="selected" value="%s">%s</option>' % (tag, tag)
+                        html += '<option selected="selected" value="{0!s}">{1!s}</option>'.format(tag, tag)
                     else:
-                        html += '<option value="%s">%s</option>' % (tag, tag)
+                        html += '<option value="{0!s}">{1!s}</option>'.format(tag, tag)
                 html += '</select>'
                 stream = stream | Transformer('fieldset[@id="basic-information"]').append(HTML(html))
         return stream


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:hdx-ckan?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:hdx-ckan?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
