### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -56,7 +56,7 @@ class RevisionController(base.BaseController):
             revision_query = model.repo.history()
             revision_query = revision_query.filter(
                 model.Revision.timestamp >= since_when).filter(
-                    model.Revision.id != None)
+                    model.Revision.id is not None)
             revision_query = revision_query.limit(maxresults)
             for revision in revision_query:
                 package_indications = []

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -71,7 +71,7 @@ def query_yes_no(question, default="yes"):
     """
     valid = {"yes":"yes",   "y":"yes",  "ye":"yes",
              "no":"no",     "n":"no"}
-    if default == None:
+    if default is None:
         prompt = " [y/n] "
     elif default == "yes":
         prompt = " [Y/n] "
@@ -684,7 +684,7 @@ class Sysadmin(CkanCommand):
         import ckan.model as model
 
         cmd = self.args[0] if self.args else None
-        if cmd == None or cmd == 'list':
+        if cmd is None or cmd == 'list':
             self.list()
         elif cmd == 'add':
             self.add()
@@ -1083,7 +1083,7 @@ class Ratings(CkanCommand):
         import ckan.model as model
         q = model.Session.query(model.Rating)
         print "{0:d} ratings".format(q.count())
-        q = q.filter(model.Rating.user_id == None)
+        q = q.filter(model.Rating.user_id is None)
         print "of which {0:d} are anonymous ratings".format(q.count())
 
     def clean(self, user_ratings=True):
@@ -1091,7 +1091,7 @@ class Ratings(CkanCommand):
         q = model.Session.query(model.Rating)
         print "{0:d} ratings".format(q.count())
         if not user_ratings:
-            q = q.filter(model.Rating.user_id == None)
+            q = q.filter(model.Rating.user_id is None)
             print "of which {0:d} are anonymous ratings".format(q.count())
         ratings = q.all()
         for rating in ratings:

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -821,7 +821,7 @@ def user_list(context, data_dict):
     else:
         query = query.order_by(
             _case([(
-                _or_(model.User.fullname == None,
+                _or_(model.User.fullname is None,
                      model.User.fullname == ''),
                 model.User.name)],
                 else_=model.User.fullname))
@@ -2002,7 +2002,7 @@ def _tag_search(context, data_dict):
         q = q.filter(model.Tag.vocabulary_id == vocab.id)
     else:
         # If no vocabulary_name in data dict then show free tags only.
-        q = q.filter(model.Tag.vocabulary_id == None)
+        q = q.filter(model.Tag.vocabulary_id is None)
         # If we're searching free tags, limit results to tags that are
         # currently applied to a package.
         q = q.distinct().join(model.Tag.package_tags)

--- a/ckan/migration/versions/018_adjust_licenses.py
+++ b/ckan/migration/versions/018_adjust_licenses.py
@@ -154,7 +154,7 @@ def _switch_package_license_ids(old_ids, old_license_titles, map):
     "Returns a dict of new license ids, keyed by package id."
     new_ids = {}
     for (package_id, old_license_id) in old_ids.items():
-        if old_license_id != None:
+        if old_license_id is not None:
             old_license_title = old_license_titles[old_license_id]
             new_license_id = map[old_license_title]
             new_ids[package_id] = new_license_id

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -239,7 +239,7 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
                       and_(Member.group_id == Group.id,
                            Member.table_name == 'group',
                            Member.state == 'active')).\
-            filter(Member.id == None).\
+            filter(Member.id is None).\
             filter(Group.type == type).\
             filter(Group.state == 'active').\
             order_by(Group.title).all()

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -78,7 +78,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
         '''Returns a package object referenced by its id or name.'''
         query = meta.Session.query(cls).filter(cls.id==reference)
         pkg = query.first()
-        if pkg == None:
+        if pkg is None:
             pkg = cls.by_name(reference)
         return pkg
     # Todo: Make sure package names can't be changed to look like package IDs?
@@ -159,7 +159,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
         if vocab:
             query = query.filter(model.Tag.vocabulary_id == vocab.id)
         else:
-            query = query.filter(model.Tag.vocabulary_id == None)
+            query = query.filter(model.Tag.vocabulary_id is None)
         query = query.order_by(model.Tag.name)
         tags = query.all()
         return tags

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -145,7 +145,7 @@ class Resource(vdm.sqlalchemy.RevisionedObjectMixin,
         :rtype: list of ckan.model.Resource objects
         '''
         query = meta.Session.query(cls).outerjoin(ckan.model.ResourceView) \
-                    .filter(ckan.model.ResourceView.id == None)
+                    .filter(ckan.model.ResourceView.id is None)
 
         if formats:
             lowercase_formats = [f.lower() for f in formats]

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -91,7 +91,7 @@ class Tag(domain_object.DomainObject):
                 Tag.vocabulary_id==vocab.id)
         else:
             query = meta.Session.query(Tag).filter(Tag.name==name).filter(
-                Tag.vocabulary_id==None)
+                Tag.vocabulary_idisNone)
         query = query.autoflush(autoflush)
         tag = query.first()
         return tag
@@ -190,7 +190,7 @@ class Tag(domain_object.DomainObject):
                 raise ckan.logic.NotFound("could not find vocabulary '{0!s}'".format(vocab_id_or_name))
             query = meta.Session.query(Tag).filter(Tag.vocabulary_id==vocab.id)
         else:
-            query = meta.Session.query(Tag).filter(Tag.vocabulary_id == None)
+            query = meta.Session.query(Tag).filter(Tag.vocabulary_id is None)
             query = query.distinct().join(PackageTag)
             query = query.filter_by(state='active')
         return query

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -183,7 +183,7 @@ class User(vdm.sqlalchemy.StatefulObjectMixin,
 
     @classmethod
     def check_name_available(cls, name):
-        return cls.by_name(name) == None
+        return cls.by_name(name) is None
 
     def as_dict(self):
         _dict = domain_object.DomainObject.as_dict(self)

--- a/ckan/tests/functional/api/base.py
+++ b/ckan/tests/functional/api/base.py
@@ -80,7 +80,7 @@ class ApiTestCase(object):
 
         [1] http://www.w3.org/International/articles/idn-and-iri/
         """
-        assert self.api_version != None, "API version is missing."
+        assert self.api_version is not None, "API version is missing."
         base = '/api'
         if self.api_version:
             base += '/{0!s}'.format(self.api_version)

--- a/ckan/tests/misc/test_sync.py
+++ b/ckan/tests/misc/test_sync.py
@@ -54,7 +54,7 @@ class _TestSync(TestController):
 
     def sub_app_get_deserialized(offset):
         res = sub_app_get(offset)
-        if res == None:
+        if res is None:
             return None
         else:
             return json.loads(res)
@@ -74,7 +74,7 @@ class _TestSync(TestController):
         
         # find id of last revision synced
         last_sync_rev_id = self._last_synced_revision_id[server]
-        assert last_sync_rev_id == None # no syncs yet
+        assert last_sync_rev_id is None # no syncs yet
 
         # get revision ids since then
         remote_rev_ids = self.sub_app_get_deserialized('{0!s}/api/search/revision?since={1!s}'.format(server, last_sync_rev_id))

--- a/ckan/tests/models/test_package.py
+++ b/ckan/tests/models/test_package.py
@@ -93,7 +93,7 @@ class TestPackage:
         # Check unregistered license_id causes license to be 'None'.
         package = model.Package.by_name(self.name)
         package.license_id = u'zzzzzzz'
-        assert package.license == None
+        assert package.license is None
         model.Session.remove() # forget change
 
     def test_as_dict(self):

--- a/ckan/tests/wsgi_ckanclient.py
+++ b/ckan/tests/wsgi_ckanclient.py
@@ -29,7 +29,7 @@ class WsgiCkanClient(CkanClient):
             print "ckanclient: Opening {0!s}".format(location)
         self.last_location = location
 
-        if data != None:
+        if data is not None:
             data = urllib.urlencode({data: 1})
         # Don't use request beyond getting the method
         req = ApiRequest(location, data, headers, method=method)

--- a/ckanext-hdx_org_group/ckanext/hdx_org_group/actions/get.py
+++ b/ckanext-hdx_org_group/ckanext/hdx_org_group/actions/get.py
@@ -74,7 +74,7 @@ def hdx_datasets_for_group(context, data_dict):
         key + ":" + value for key, value in data_dict.iteritems() if key not in skipped_keys]
     search_param_list.append(u'groups:{}'.format(id))
 
-    if search_param_list != None:
+    if search_param_list is not None:
         new_data_dict['fq'] = " ".join(
             search_param_list) + ' +dataset_type:dataset'
 

--- a/ckanext-hdx_org_group/ckanext/hdx_org_group/helpers/organization_helper.py
+++ b/ckanext-hdx_org_group/ckanext/hdx_org_group/helpers/organization_helper.py
@@ -343,7 +343,7 @@ def hdx_group_or_org_update(context, data_dict, is_org=False):
         data_dict['customization']['image_rect'] = ''
         customization['image_rect'] = ''
 
-    if 'image_sq_upload' in data_dict and data_dict['image_sq_upload'] != '' and data_dict['image_sq_upload'] != None:
+    if 'image_sq_upload' in data_dict and data_dict['image_sq_upload'] != '' and data_dict['image_sq_upload'] is not None:
         # Although weird, the FieldStorage instance has a boolean value of False so we need to compare to None
 
         # If old image was uploaded remove it
@@ -355,7 +355,7 @@ def hdx_group_or_org_update(context, data_dict, is_org=False):
                                  'image_sq_upload', 'clear_upload')
 
     if 'image_rect_upload' in data_dict and data_dict['image_rect_upload'] != '' \
-            and data_dict['image_rect_upload'] != None:
+            and data_dict['image_rect_upload'] is not None:
         # Although weird, the FieldStorage instance has a boolean value of False so we need to compare to None
 
         if customization['image_rect']:
@@ -367,7 +367,7 @@ def hdx_group_or_org_update(context, data_dict, is_org=False):
     storage_path = uploader.get_storage_path()
     ##Rearrange things the way we need them
     try:
-        if data_dict['image_sq'] != '' and data_dict['image_sq'] != None:
+        if data_dict['image_sq'] != '' and data_dict['image_sq'] is not None:
             data_dict['customization']['image_sq'] = data_dict['image_sq']
         else:
             data_dict['customization']['image_sq'] = customization['image_sq']
@@ -375,7 +375,7 @@ def hdx_group_or_org_update(context, data_dict, is_org=False):
         data_dict['customization']['image_sq'] = ''
 
     try:
-        if data_dict['image_rect'] != '' and data_dict['image_rect'] != None:
+        if data_dict['image_rect'] != '' and data_dict['image_rect'] is not None:
             data_dict['customization']['image_rect'] = data_dict['image_rect']
         else:
             data_dict['customization']['image_rect'] = customization['image_rect']
@@ -515,7 +515,7 @@ def hdx_group_or_org_create(context, data_dict, is_org=False):
     except:
         data_dict['customization'] = {}
 
-    if 'image_sq_upload' in data_dict and data_dict['image_sq_upload'] != '' and data_dict['image_sq_upload'] != None:
+    if 'image_sq_upload' in data_dict and data_dict['image_sq_upload'] != '' and data_dict['image_sq_upload'] is not None:
         # If old image was uploaded remove it
         if customization['image_sq']:
             remove_image(customization['image_sq'])
@@ -525,7 +525,7 @@ def hdx_group_or_org_create(context, data_dict, is_org=False):
                                  'image_sq_upload', 'clear_upload')
 
     if 'image_rect_upload' in data_dict and data_dict['image_rect_upload'] != '' and data_dict[
-        'image_rect_upload'] != None:
+        'image_rect_upload'] is not None:
         if customization['image_rect']:
             remove_image(customization['image_rect'])
         upload2 = uploader.Upload('group', customization['image_rect'])
@@ -535,7 +535,7 @@ def hdx_group_or_org_create(context, data_dict, is_org=False):
     storage_path = uploader.get_storage_path()
     ##Rearrange things the way we need them
     try:
-        if data_dict['image_sq'] != '' and data_dict['image_sq'] != None:
+        if data_dict['image_sq'] != '' and data_dict['image_sq'] is not None:
             data_dict['customization']['image_sq'] = data_dict['image_sq']
         else:
             data_dict['customization']['image_sq'] = customization['image_sq']
@@ -543,7 +543,7 @@ def hdx_group_or_org_create(context, data_dict, is_org=False):
         data_dict['customization']['image_sq'] = ''
 
     try:
-        if data_dict['image_rect'] != '' and data_dict['image_rect'] != None:
+        if data_dict['image_rect'] != '' and data_dict['image_rect'] is not None:
             data_dict['customization']['image_rect'] = data_dict['image_rect']
         else:
             data_dict['customization']['image_rect'] = customization['image_rect']

--- a/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
+++ b/ckanext-hdx_package/ckanext/hdx_package/helpers/helpers.py
@@ -118,7 +118,7 @@ def hdx_find_license_name(license_id, license_name):
     """
     Look up license name by id
     """
-    if license_name == None or len(license_name) == 0 or license_name == license_id:
+    if license_name is None or len(license_name) == 0 or license_name == license_id:
         original_license_list = (
             l.as_dict() for l in package.Package._license_register.licenses)
         license_dict = {l['id']: l['title']

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -169,7 +169,7 @@ class TestDatastoreUpsert(tests.WsgiAppCase):
         records = results.fetchall()
         assert records[2][u'b\xfck'] == hhguide
         assert records[2].author == 'adams'
-        assert records[2].published == None
+        assert records[2].published is None
         self.Session.remove()
 
         data = {
@@ -507,7 +507,7 @@ class TestDatastoreUpdate(tests.WsgiAppCase):
         records = results.fetchall()
         assert records[2][u'b\xfck'] == hhguide
         assert records[2].author == 'adams'
-        assert records[2].published == None
+        assert records[2].published is None
 
     def test_update_missing_key(self):
         data = {

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -62,7 +62,7 @@ class Stats(object):
         s = select([member.c.group_id, func.count(member.c.table_id)]).\
             select_from(j).\
             group_by(member.c.group_id).\
-            where(and_(member.c.group_id!=None, member.c.table_name=='package', package.c.private==False, package.c.state=='active')).\
+            where(and_(member.c.group_idis notNone, member.c.table_name=='package', package.c.private==False, package.c.state=='active')).\
             order_by(func.count(member.c.table_id).desc()).\
             limit(limit)
 
@@ -105,7 +105,7 @@ class Stats(object):
         package = table('package')
         s = select([user_object_role.c.user_id, func.count(user_object_role.c.role)], from_obj=[user_object_role.join(package_role).join(package)]).\
             where(user_object_role.c.role==model.authz.Role.ADMIN).\
-            where(user_object_role.c.user_id!=None).\
+            where(user_object_role.c.user_idis notNone).\
             where(and_(package.c.private==False, package.c.state=='active')). \
             group_by(user_object_role.c.user_id).\
             order_by(func.count(user_object_role.c.role).desc()).\

--- a/fabfile.py
+++ b/fabfile.py
@@ -93,9 +93,9 @@ def config_local(base_dir, ckan_instance_name, db_user=None, db_host=None,
         env.db_pass = db_pass
     if db_host:
         env.db_host = db_host
-    if skip_setup_db != None:
+    if skip_setup_db is not None:
         env.skip_setup_db = skip_setup_db    
-    if no_sudo != None:
+    if no_sudo is not None:
         env.no_sudo = no_sudo
     env.revision = revision if revision else 'metastable'
         
@@ -364,7 +364,7 @@ def apache_config(set_config=None):
     available_configs = get_available_apache_configs()
     print 'Available modes: {0!s}'.format(available_configs)
 
-    if set_config == None:
+    if set_config is None:
         print 'Current mode: {0!s}'.format(enabled_config)
     else:
         assert set_config in available_configs
@@ -661,7 +661,7 @@ def _run_in_pyenv(command):
 
 def _pip_cmd(command):
     '''Looks for pip in the pyenv before finding it in the cmd pyenv'''
-    if env.pip_from_pyenv == None:
+    if env.pip_from_pyenv is None:
         env.pip_from_pyenv = bool(exists(os.path.join(env.pyenv_dir, 'bin', 'pip')))
     if env.pip_from_pyenv:
         return _run_in_pyenv(command)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:hdx-ckan?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:hdx-ckan?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
